### PR TITLE
Set up Flask backend with SQLite and API endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,17 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_marshmallow import Marshmallow
+from flask_cors import CORS
+
+app = Flask(__name__)
+app.config.from_object('config')
+
+db = SQLAlchemy(app)
+ma = Marshmallow(app)
+CORS(app)
+
+from app.routes.drills import drills_bp
+from app.routes.practice_plans import practice_plans_bp
+
+app.register_blueprint(drills_bp, url_prefix='/api/drills')
+app.register_blueprint(practice_plans_bp, url_prefix='/api/practice-plans')

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,28 @@
+from app import db
+
+class Drill(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    brief_description = db.Column(db.String(255), nullable=False)
+    detailed_description = db.Column(db.Text)
+    skill_level = db.Column(db.String(50), nullable=False)
+    complexity = db.Column(db.String(50))
+    suggested_length = db.Column(db.String(50), nullable=False)
+    number_of_people = db.Column(db.Integer)
+    skills_focused_on = db.Column(db.String(255), nullable=False)
+    positions_focused_on = db.Column(db.String(255), nullable=False)
+    video_link = db.Column(db.String(255))
+    images = db.Column(db.PickleType)
+
+class PracticePlan(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    practice_goals = db.Column(db.String(255))
+    phase_of_season = db.Column(db.String(50))
+    number_of_participants = db.Column(db.Integer)
+    level_of_experience = db.Column(db.String(50))
+    skills_focused_on = db.Column(db.String(255))
+    overview = db.Column(db.Text)
+    time_per_drill = db.Column(db.String(50))
+    breaks_between_drills = db.Column(db.String(50))
+    total_practice_time = db.Column(db.String(50))

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,10 @@
+from flask import Blueprint
+
+main_bp = Blueprint('main', __name__)
+
+def register_blueprints(app):
+    from app.routes.drills import drills_bp
+    from app.routes.practice_plans import practice_plans_bp
+
+    app.register_blueprint(drills_bp, url_prefix='/api/drills')
+    app.register_blueprint(practice_plans_bp, url_prefix='/api/practice-plans')

--- a/app/routes/drills.py
+++ b/app/routes/drills.py
@@ -1,0 +1,30 @@
+from flask import Blueprint, request, jsonify
+from app import db
+from app.models import Drill
+from app.schemas import DrillSchema
+
+drills_bp = Blueprint('drills', __name__)
+
+@drills_bp.route('/', methods=['POST'])
+def create_drill():
+    data = request.get_json()
+    drill_schema = DrillSchema()
+    errors = drill_schema.validate(data)
+    if errors:
+        return jsonify(errors), 400
+    drill = drill_schema.load(data)
+    db.session.add(drill)
+    db.session.commit()
+    return drill_schema.jsonify(drill), 201
+
+@drills_bp.route('/', methods=['GET'])
+def get_drills():
+    drills = Drill.query.all()
+    drill_schema = DrillSchema(many=True)
+    return drill_schema.jsonify(drills), 200
+
+@drills_bp.route('/<int:id>', methods=['GET'])
+def get_drill(id):
+    drill = Drill.query.get_or_404(id)
+    drill_schema = DrillSchema()
+    return drill_schema.jsonify(drill), 200

--- a/app/routes/practice_plans.py
+++ b/app/routes/practice_plans.py
@@ -1,0 +1,30 @@
+from flask import Blueprint, request, jsonify
+from app import db
+from app.models import PracticePlan
+from app.schemas import PracticePlanSchema
+
+practice_plans_bp = Blueprint('practice_plans', __name__)
+
+@practice_plans_bp.route('/', methods=['POST'])
+def create_practice_plan():
+    data = request.get_json()
+    practice_plan_schema = PracticePlanSchema()
+    errors = practice_plan_schema.validate(data)
+    if errors:
+        return jsonify(errors), 400
+    practice_plan = practice_plan_schema.load(data)
+    db.session.add(practice_plan)
+    db.session.commit()
+    return practice_plan_schema.jsonify(practice_plan), 201
+
+@practice_plans_bp.route('/', methods=['GET'])
+def get_practice_plans():
+    practice_plans = PracticePlan.query.all()
+    practice_plan_schema = PracticePlanSchema(many=True)
+    return practice_plan_schema.jsonify(practice_plans), 200
+
+@practice_plans_bp.route('/<int:id>', methods=['GET'])
+def get_practice_plan(id):
+    practice_plan = PracticePlan.query.get_or_404(id)
+    practice_plan_schema = PracticePlanSchema()
+    return practice_plan_schema.jsonify(practice_plan), 200

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,28 @@
+from marshmallow import Schema, fields, validate
+
+class DrillSchema(Schema):
+    id = fields.Int(dump_only=True)
+    name = fields.Str(required=True, validate=validate.Length(max=100))
+    brief_description = fields.Str(required=True, validate=validate.Length(max=255))
+    detailed_description = fields.Str()
+    skill_level = fields.Str(required=True, validate=validate.Length(max=50))
+    complexity = fields.Str(validate=validate.Length(max=50))
+    suggested_length = fields.Str(required=True, validate=validate.Length(max=50))
+    number_of_people = fields.Int()
+    skills_focused_on = fields.Str(required=True, validate=validate.Length(max=255))
+    positions_focused_on = fields.Str(required=True, validate=validate.Length(max=255))
+    video_link = fields.Str(validate=validate.Length(max=255))
+    images = fields.List(fields.Str())
+
+class PracticePlanSchema(Schema):
+    id = fields.Int(dump_only=True)
+    name = fields.Str(required=True, validate=validate.Length(max=100))
+    practice_goals = fields.Str(validate=validate.Length(max=255))
+    phase_of_season = fields.Str(validate=validate.Length(max=50))
+    number_of_participants = fields.Int()
+    level_of_experience = fields.Str(validate=validate.Length(max=50))
+    skills_focused_on = fields.Str(validate=validate.Length(max=255))
+    overview = fields.Str()
+    time_per_drill = fields.Str(validate=validate.Length(max=50))
+    breaks_between_drills = fields.Str(validate=validate.Length(max=50))
+    total_practice_time = fields.Str(validate=validate.Length(max=50))

--- a/config.py
+++ b/config.py
@@ -1,0 +1,7 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY') or 'you-will-never-guess'
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or 'sqlite:///app.db'
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    CORS_HEADERS = 'Content-Type'

--- a/cypress/integration/drill_creation.spec.js
+++ b/cypress/integration/drill_creation.spec.js
@@ -1,0 +1,23 @@
+describe('Drill Creation', () => {
+  it('should create a new drill and verify its existence', () => {
+    cy.visit('/drills/create');
+
+    cy.get('input#name').type('Test Drill');
+    cy.get('input#briefDescription').type('A brief description of the test drill');
+    cy.get('textarea#detailedDescription').type('A detailed description of the test drill');
+    cy.get('input#skillLevel').type('Beginner');
+    cy.get('input#complexity').type('Low');
+    cy.get('input#suggestedLength').type('10 minutes');
+    cy.get('input#numberOfPeople').type('5');
+    cy.get('input#skillsFocusedOn').type('Passing, Shooting');
+    cy.get('input#positionsFocusedOn').type('Forward, Midfield');
+    cy.get('input#videoLink').type('http://example.com/video');
+    cy.get('input#images').attachFile('path/to/image1.jpg');
+    cy.get('input#images').attachFile('path/to/image2.jpg');
+
+    cy.get('button[type="submit"]').click();
+
+    cy.visit('/drills');
+    cy.contains('Test Drill').should('exist');
+  });
+});

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,29 @@
+# Migrations
+
+This directory contains the migration scripts for the SQLite database used in the Flask application.
+
+## Running Migrations
+
+To run the migrations, follow these steps:
+
+1. **Initialize the migration environment**:
+   ```bash
+   flask db init
+   ```
+
+2. **Create a new migration script**:
+   ```bash
+   flask db migrate -m "Initial migration"
+   ```
+
+3. **Apply the migration to the database**:
+   ```bash
+   flask db upgrade
+   ```
+
+## Commands
+
+- `flask db init`: Initializes the migration environment.
+- `flask db migrate -m "message"`: Creates a new migration script with the specified message.
+- `flask db upgrade`: Applies the migration to the database.
+- `flask db downgrade`: Reverts the last migration applied to the database.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,74 @@
+from __future__ import with_statement
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+import os
+import sys
+
+# Add the app directory to the system path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app')))
+
+from app import app, db
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = db.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+    This configures the context with just a URL
+    and not an Engine, though an Engine is also acceptable
+    here. By skipping the Engine creation we don't even need
+    a DBAPI to be available.
+    Calls to context.execute() here emit the given string to the
+    script output.
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/initial_migration.py
+++ b/migrations/versions/initial_migration.py
@@ -1,0 +1,47 @@
+"""Initial migration script to create tables for drills and practice plans."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Create drills table
+    op.create_table(
+        'drill',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(100), nullable=False),
+        sa.Column('brief_description', sa.String(255), nullable=False),
+        sa.Column('detailed_description', sa.Text),
+        sa.Column('skill_level', sa.String(50), nullable=False),
+        sa.Column('complexity', sa.String(50)),
+        sa.Column('suggested_length', sa.String(50), nullable=False),
+        sa.Column('number_of_people', sa.Integer),
+        sa.Column('skills_focused_on', sa.String(255), nullable=False),
+        sa.Column('positions_focused_on', sa.String(255), nullable=False),
+        sa.Column('video_link', sa.String(255)),
+        sa.Column('images', sa.PickleType)
+    )
+
+    # Create practice_plans table
+    op.create_table(
+        'practice_plan',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(100), nullable=False),
+        sa.Column('practice_goals', sa.String(255)),
+        sa.Column('phase_of_season', sa.String(50)),
+        sa.Column('number_of_participants', sa.Integer),
+        sa.Column('level_of_experience', sa.String(50)),
+        sa.Column('skills_focused_on', sa.String(255)),
+        sa.Column('overview', sa.Text),
+        sa.Column('time_per_drill', sa.String(50)),
+        sa.Column('breaks_between_drills', sa.String(50)),
+        sa.Column('total_practice_time', sa.String(50))
+    )
+
+
+def downgrade():
+    # Drop practice_plans table
+    op.drop_table('practice_plan')
+
+    # Drop drills table
+    op.drop_table('drill')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask==2.0.1
+Flask-SQLAlchemy==2.5.1
+marshmallow==3.13.0
+Flask-CORS==3.0.10
+pytest==6.2.4
+Flask-Migrate==3.1.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,91 @@
+import pytest
+from app import create_app, db
+from app.models import Drill, PracticePlan
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update({
+        "TESTING": True,
+    })
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_create_drill(client):
+    response = client.post('/api/drills', json={
+        'name': 'Drill 1',
+        'brief_description': 'Brief description',
+        'skill_level': 'Beginner',
+        'suggested_length': '10 minutes',
+        'skills_focused_on': 'Skill 1',
+        'positions_focused_on': 'Position 1'
+    })
+    assert response.status_code == 201
+    assert response.json['name'] == 'Drill 1'
+
+def test_get_drills(client):
+    client.post('/api/drills', json={
+        'name': 'Drill 1',
+        'brief_description': 'Brief description',
+        'skill_level': 'Beginner',
+        'suggested_length': '10 minutes',
+        'skills_focused_on': 'Skill 1',
+        'positions_focused_on': 'Position 1'
+    })
+    response = client.get('/api/drills')
+    assert response.status_code == 200
+    assert len(response.json) == 1
+
+def test_get_drill_by_id(client):
+    response = client.post('/api/drills', json={
+        'name': 'Drill 1',
+        'brief_description': 'Brief description',
+        'skill_level': 'Beginner',
+        'suggested_length': '10 minutes',
+        'skills_focused_on': 'Skill 1',
+        'positions_focused_on': 'Position 1'
+    })
+    drill_id = response.json['id']
+    response = client.get(f'/api/drills/{drill_id}')
+    assert response.status_code == 200
+    assert response.json['name'] == 'Drill 1'
+
+def test_create_practice_plan(client):
+    response = client.post('/api/practice-plans', json={
+        'name': 'Practice Plan 1',
+        'practice_goals': 'Goals',
+        'phase_of_season': 'Pre-season',
+        'number_of_participants': 10
+    })
+    assert response.status_code == 201
+    assert response.json['name'] == 'Practice Plan 1'
+
+def test_get_practice_plans(client):
+    client.post('/api/practice-plans', json={
+        'name': 'Practice Plan 1',
+        'practice_goals': 'Goals',
+        'phase_of_season': 'Pre-season',
+        'number_of_participants': 10
+    })
+    response = client.get('/api/practice-plans')
+    assert response.status_code == 200
+    assert len(response.json) == 1
+
+def test_get_practice_plan_by_id(client):
+    response = client.post('/api/practice-plans', json={
+        'name': 'Practice Plan 1',
+        'practice_goals': 'Goals',
+        'phase_of_season': 'Pre-season',
+        'number_of_participants': 10
+    })
+    practice_plan_id = response.json['id']
+    response = client.get(f'/api/practice-plans/{practice_plan_id}')
+    assert response.status_code == 200
+    assert response.json['name'] == 'Practice Plan 1'

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "app/**/*.py",
+      "use": "@vercel/python"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "/app/routes/$1.py"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #3

Set up the basic structure of the Python backend using Flask to create a RESTful API for drill creation, retrieval, and practice plan management.

* **Initialize Flask Project**
  - Add `app/__init__.py` to initialize the Flask application, configure SQLite database, and register blueprints.
  - Add `app/routes/__init__.py` to define and register main blueprint for routes.
  - Add `config.py` to define configuration settings for the Flask application.

* **Set Up SQLite Database**
  - Add `app/models.py` to define database models for `Drill` and `PracticePlan`.
  - Add `migrations/env.py` and `migrations/versions/initial_migration.py` to set up migration environment and create initial tables.
  - Add `migrations/README` with instructions for running database migrations.

* **Create API Endpoints**
  - Add `app/routes/drills.py` to create routes for creating, retrieving, and getting details of drills.
  - Add `app/routes/practice_plans.py` to create routes for creating, retrieving, and getting details of practice plans.

* **Data Validation and Error Handling**
  - Add `app/schemas.py` to define Marshmallow schemas for `Drill` and `PracticePlan` with data validation rules.

* **CORS Configuration**
  - Configure CORS in `app/__init__.py` to allow communication with the SvelteKit frontend.

* **Testing**
  - Add `tests/test_api.py` to write unit tests for API endpoints using Pytest.

* **Deployment**
  - Add `vercel.json` to configure Vercel for deploying Flask backend.

* **Cypress Testing**
  - Add `cypress/integration/drill_creation.spec.js` to write a Cypress test for drill creation and retrieval.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill/issues/3?shareId=054c095e-33dd-4f91-afc6-c7449e973c8d).