### PR TITLE
Fix dependencies for mock-aws-s3, aws-sdk, and nock

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
 	},
 	"dependencies": {
 		"svelte-forms-lib": "^1.9.7",
-		"svelte-routing": "^1.5.0"
+		"svelte-routing": "^1.5.0",
+		"mock-aws-s3": "^5.0.0",
+		"aws-sdk": "^2.1048.0",
+		"nock": "^13.2.4"
 	},
 	"type": "module"
 }


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill?shareId=277ab123-7de1-4539-acfd-37c1b690b958).