### PR TITLE
Fix drill schema to accept strings for list fields

### DIFF
--- a/app/routes/drills.py
+++ b/app/routes/drills.py
@@ -12,6 +12,15 @@ def create_drill():
     try:
         data = request.get_json()
         print("Request data: ", data)
+        
+        # Check if 'skills_focused_on' is a string and convert to list
+        if isinstance(data.get('skills_focused_on'), str):
+            data['skills_focused_on'] = [data['skills_focused_on']]
+        
+        # Check if 'positions_focused_on' is a string and convert to list
+        if isinstance(data.get('positions_focused_on'), str):
+            data['positions_focused_on'] = [data['positions_focused_on']]
+        
         drill_schema = DrillSchema()
         
         # Validate the data

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,3 +89,17 @@ def test_get_practice_plan_by_id(client):
     response = client.get(f'/api/practice-plans/{practice_plan_id}')
     assert response.status_code == 200
     assert response.json['name'] == 'Practice Plan 1'
+
+def test_create_drill_with_string_fields(client):
+    response = client.post('/api/drills', json={
+        'name': 'Drill 2',
+        'brief_description': 'Another brief description',
+        'skill_level': 'Intermediate',
+        'suggested_length': '15 minutes',
+        'skills_focused_on': 'Skill 2',
+        'positions_focused_on': 'Position 2'
+    })
+    assert response.status_code == 201
+    assert response.json['name'] == 'Drill 2'
+    assert response.json['skills_focused_on'] == ['Skill 2']
+    assert response.json['positions_focused_on'] == ['Position 2']


### PR DESCRIPTION
Add handling for string inputs for 'skills_focused_on' and 'positions_focused_on' fields in the drill creation endpoint.

* **app/routes/drills.py**
  - Check if 'skills_focused_on' and 'positions_focused_on' are strings and convert them to lists of length one before validation.
* **tests/test_api.py**
  - Add a test case to verify that passing a string for 'skills_focused_on' and 'positions_focused_on' results in a list of length one in the response.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill?shareId=0390d3da-2439-4db1-86ac-f6973e1d3642).