### PR TITLE
Fix API drill endpoint and add logging

### DIFF
--- a/app/routes/drills.py
+++ b/app/routes/drills.py
@@ -45,6 +45,13 @@ def get_drills():
 
 @drills_bp.route('/<int:id>', methods=['GET'])
 def get_drill(id):
-    drill = Drill.query.get_or_404(id)
-    drill_schema = DrillSchema()
-    return jsonify(drill_schema.dump(drill)), 200
+    print(f"Received a GET request to /api/drills/{id}")
+    try:
+        drill = Drill.query.get_or_404(id)
+        print(f"Drill found: {drill}")
+        drill_schema = DrillSchema()
+        return jsonify(drill_schema.dump(drill)), 200
+    except Exception as e:
+        import traceback
+        print(f"Error occurred while fetching drill with ID {id}: ", str(e), type(e), traceback.format_exc())
+        return jsonify({"error": f"Drill with ID {id} not found"}), 404

--- a/src/routes/api/drills/[id]/+server.js
+++ b/src/routes/api/drills/[id]/+server.js
@@ -1,0 +1,19 @@
+import { json } from '@sveltejs/kit';
+
+const API_BASE_URL = 'http://127.0.0.1:5000';
+
+export async function GET({ params }) {
+    const { id } = params;
+    try {
+        const response = await fetch(`${API_BASE_URL}/api/drills/${id}`);
+        if (response.ok) {
+            const data = await response.json();
+            return json(data);
+        } else {
+            return json({ error: `Drill with ID ${id} not found` }, { status: 404 });
+        }
+    } catch (error) {
+        console.error(`Error occurred while fetching drill with ID ${id}:`, error);
+        return json({ error: 'An error occurred while fetching the drill', details: error.toString() }, { status: 500 });
+    }
+}


### PR DESCRIPTION
Add logging and error handling to the `get_drill` function and create a new API endpoint for fetching drills by ID.

* **Logging and Error Handling in `get_drill` function:**
  - Add logging statements before and after querying the drill by ID in `app/routes/drills.py`.
  - Add a try-catch block to handle the 404 error and return a JSON response with a 404 status code and error message.

* **New API Endpoint for Fetching Drills by ID:**
  - Create a new file `src/routes/api/drills/[id]/+server.js` to handle the GET request for a specific drill by ID.
  - Add a try-catch block to handle the 404 error and return a JSON response with a 404 status code and error message.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill?shareId=0c461f1b-2d2b-4375-adfe-ff0c85e74c7f).