### PR TITLE
Refactor project structure for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,24 @@ QDrill is a web-based application designed to be a sports drill bank and practic
    ```bash
    flask db upgrade
    ```
+
+### Deployment on Vercel
+
+To deploy both the frontend and backend on Vercel, follow these steps:
+
+1. **Install Vercel CLI**:
+   ```bash
+   npm install -g vercel
+   ```
+
+2. **Login to Vercel**:
+   ```bash
+   vercel login
+   ```
+
+3. **Deploy the application**:
+   ```bash
+   vercel --prod
+   ```
+
+This will deploy both the SvelteKit frontend and the Flask backend to Vercel, making your application accessible on your custom domain.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"test:unit": "vitest",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write .",
-		"deploy": "vercel --prod"
+		"deploy": "vercel --prod && vercel --prod --cwd app"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^4.5.10",

--- a/vercel.json
+++ b/vercel.json
@@ -4,12 +4,20 @@
     {
       "src": "app/**/*.py",
       "use": "@vercel/python"
+    },
+    {
+      "src": "src/**/*",
+      "use": "@sveltejs/adapter-vercel"
     }
   ],
   "routes": [
     {
       "src": "/api/(.*)",
       "dest": "/app/routes/$1.py"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/src/$1"
     }
   ]
 }


### PR DESCRIPTION
Refactor the project structure to set up for Vercel deployment of both frontend and backend.

* **vercel.json**
  - Add a new build for the SvelteKit frontend using the Vercel adapter.
  - Update the routes to include the frontend routes.

* **README.md**
  - Update the deployment section to include instructions for deploying both the frontend and backend on Vercel.

* **package.json**
  - Update the deploy script to include both frontend and backend deployment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill?shareId=3c75493d-e3cf-4071-aea1-f0ca8d49f2d4).