### PR TITLE
Fix error when evaluating SSR module in drills API

### DIFF
--- a/src/routes/api/drills/+server.js
+++ b/src/routes/api/drills/+server.js
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
-import { Client } from '@vercel/postgres';
+import { createClient } from '@vercel/postgres';
 
-const client = new Client();
+const client = createClient();
 await client.connect();
 
 export async function POST({ request }) {

--- a/src/routes/api/practice-plans/+server.js
+++ b/src/routes/api/practice-plans/+server.js
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
-import { Client } from '@vercel/postgres';
+import { createClient } from '@vercel/postgres';
 
-const client = new Client();
+const client = createClient();
 await client.connect();
 
 export async function POST({ request }) {


### PR DESCRIPTION
Fix the TypeError by correcting the import and instantiation of the `Client` from `@vercel/postgres`.

* **src/routes/api/drills/+server.js**
  - Replace `import { Client } from '@vercel/postgres';` with `import { createClient } from '@vercel/postgres';`
  - Replace `const client = new Client();` with `const client = createClient();`

* **src/routes/api/practice-plans/+server.js**
  - Replace `import { Client } from '@vercel/postgres';` with `import { createClient } from '@vercel/postgres';`
  - Replace `const client = new Client();` with `const client = createClient();`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill?shareId=34ad54a8-e780-4367-90a3-6cb3e5fdd937).