### PR TITLE
Fix drill array handling in server code

### DIFF
--- a/src/routes/api/drills/+server.js
+++ b/src/routes/api/drills/+server.js
@@ -6,7 +6,15 @@ await client.connect();
 
 export async function POST({ request }) {
     const drill = await request.json();
-    const { name, brief_description, detailed_description, skill_level, complexity, suggested_length, number_of_people, skills_focused_on, positions_focused_on, video_link, images } = drill;
+    let { name, brief_description, detailed_description, skill_level, complexity, suggested_length, number_of_people, skills_focused_on, positions_focused_on, video_link, images } = drill;
+
+    if (typeof skills_focused_on === 'string') {
+        skills_focused_on = [skills_focused_on];
+    }
+
+    if (typeof positions_focused_on === 'string') {
+        positions_focused_on = [positions_focused_on];
+    }
 
     try {
         const result = await client.query(


### PR DESCRIPTION
Update `POST` function in `src/routes/api/drills/+server.js` to handle single string inputs for `skills_focused_on` and `positions_focused_on`.

* Check if `skills_focused_on` is a string and convert it to an array of length one.
* Check if `positions_focused_on` is a string and convert it to an array of length one.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill?shareId=b5f4228e-c0f7-4a55-9e81-2d4035682500).