### PR TITLE
Update drill creation form

### DIFF
--- a/cypress/e2e/drill_creation.cy.js
+++ b/cypress/e2e/drill_creation.cy.js
@@ -5,9 +5,9 @@ describe('Drill Creation', () => {
     cy.get('input#name').type('Test Drill');
     cy.get('input#brief_description').type('A brief description of the test drill');
     cy.get('textarea#detailed_description').type('A detailed description of the test drill');
-    cy.get('select#skill_level').select('Beginner');
+    cy.get('select#skill_level').select(['Beginner', 'Intermediate']);
     cy.get('select#complexity').select('Low');
-    cy.get('select#suggested_length').select('5-15');
+    cy.get('select#suggested_length').select('5-15 minutes');
     cy.get('input#number_of_people_min').type('3');
     cy.get('input#number_of_people_max').type('10');
     cy.get('select#skills_focused_on').select(['Passing', 'Shooting']);
@@ -18,5 +18,15 @@ describe('Drill Creation', () => {
 
     cy.visit('/drills');
     cy.contains('Test Drill').should('exist');
+  });
+
+  it('should verify single and multi-choice dropdowns are visually distinct', () => {
+    cy.visit('/drills/create');
+
+    cy.get('select#skill_level').should('have.css', 'border', '2px solid blue');
+    cy.get('select#complexity').should('have.css', 'border', '2px solid green');
+    cy.get('select#suggested_length').should('have.css', 'border', '2px solid green');
+    cy.get('select#skills_focused_on').should('have.css', 'border', '2px solid blue');
+    cy.get('select#positions_focused_on').should('have.css', 'border', '2px solid blue');
   });
 });

--- a/src/routes/api/drills/+server.js
+++ b/src/routes/api/drills/+server.js
@@ -8,6 +8,10 @@ export async function POST({ request }) {
     const drill = await request.json();
     let { name, brief_description, detailed_description, skill_level, complexity, suggested_length, number_of_people, skills_focused_on, positions_focused_on, video_link, images } = drill;
 
+    if (typeof skill_level === 'string') {
+        skill_level = [skill_level];
+    }
+
     if (typeof skills_focused_on === 'string') {
         skills_focused_on = [skills_focused_on];
     }
@@ -37,6 +41,7 @@ export async function GET() {
     try {
         const result = await client.query('SELECT * FROM drills');
         const drills = result.rows.map(drill => {
+            drill.skill_level = Array.isArray(drill.skill_level) ? drill.skill_level : [];
             drill.comments = Array.isArray(drill.comments) ? drill.comments : [];
             drill.images = Array.isArray(drill.images) ? drill.images : [];
             return drill;

--- a/src/routes/api/drills/create_table.sql
+++ b/src/routes/api/drills/create_table.sql
@@ -3,7 +3,7 @@ CREATE TABLE drills (
     name VARCHAR(255) NOT NULL,
     brief_description TEXT NOT NULL,
     detailed_description TEXT,
-    skill_level VARCHAR(50) NOT NULL,
+    skill_level TEXT[] NOT NULL,
     complexity VARCHAR(50),
     suggested_length VARCHAR(50) NOT NULL,
     number_of_people_min INT DEFAULT 0,

--- a/src/routes/drills/create/+page.svelte
+++ b/src/routes/drills/create/+page.svelte
@@ -5,7 +5,7 @@
   let name = writable('');
   let brief_description = writable('');
   let detailed_description = writable('');
-  let skill_level = writable('');
+  let skill_level = writable([]);
   let complexity = writable('');
   let suggested_length = writable('');
   let number_of_people_min = writable('');
@@ -21,7 +21,7 @@
     let newErrors = {};
     if (!$name) newErrors.name = 'Name is required';
     if (!$brief_description) newErrors.brief_description = 'Brief description is required';
-    if (!$skill_level) newErrors.skill_level = 'Skill level is required';
+    if ($skill_level.length === 0) newErrors.skill_level = 'Skill level is required';
     if (!$suggested_length) newErrors.suggested_length = 'Suggested length of time is required';
     if ($skills_focused_on.length === 0) newErrors.skills_focused_on = 'Skills focused on are required';
     if ($positions_focused_on.length === 0) newErrors.positions_focused_on = 'Positions focused on are required';
@@ -105,8 +105,7 @@
 
     <div>
       <label for="skill_level">Skill Level:</label>
-      <select id="skill_level" bind:value={$skill_level}>
-        <option value="">Select Skill Level</option>
+      <select id="skill_level" bind:value={$skill_level} multiple>
         <option value="new to sport">New to Sport</option>
         <option value="beginner">Beginner</option>
         <option value="intermediate">Intermediate</option>
@@ -132,10 +131,10 @@
       <label for="suggested_length">Suggested Length of Time:</label>
       <select id="suggested_length" bind:value={$suggested_length}>
         <option value="">Select Length of Time</option>
-        <option value="0-5">0-5</option>
-        <option value="5-15">5-15</option>
-        <option value="15-30">15-30</option>
-        <option value="30-60">30-60</option>
+        <option value="0-5 minutes">0-5 minutes</option>
+        <option value="5-15 minutes">5-15 minutes</option>
+        <option value="15-30 minutes">15-30 minutes</option>
+        <option value="30-60 minutes">30-60 minutes</option>
       </select>
       {#if $errors.suggested_length}
         <p class="error">{$errors.suggested_length}</p>
@@ -228,6 +227,14 @@
     padding: 0.5rem;
     font-size: 1rem;
     width: 100%;
+  }
+
+  select[multiple] {
+    border: 2px solid blue;
+  }
+
+  select:not([multiple]) {
+    border: 2px solid green;
   }
 
   button {


### PR DESCRIPTION
Implement skill level as a multi-choice dropdown, specify minutes for suggested length of time, and visually distinguish single and multi-choice dropdowns.

* **Database Changes:**
  - Change `skill_level` field to `TEXT[]` in `src/routes/api/drills/create_table.sql`.

* **API Changes:**
  - Update `POST` method in `src/routes/api/drills/+server.js` to handle `skill_level` as an array.
  - Update `GET` method in `src/routes/api/drills/+server.js` to return `skill_level` as an array.

* **Frontend Changes:**
  - Change `skill_level` dropdown to allow multiple selections in `src/routes/drills/create/+page.svelte`.
  - Update `suggested_length` dropdown options to specify minutes in `src/routes/drills/create/+page.svelte`.
  - Style single and multi-choice dropdowns to be visually distinct in `src/routes/drills/create/+page.svelte`.

* **Test Changes:**
  - Update test to select multiple skill levels in `cypress/e2e/drill_creation.cy.js`.
  - Update test to verify suggested length of time specifies minutes in `cypress/e2e/drill_creation.cy.js`.
  - Update test to verify single and multi-choice dropdowns are visually distinct in `cypress/e2e/drill_creation.cy.js`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill?shareId=2bcf06ce-d311-4789-a84b-12beeddaf864).