### PR TITLE
If drill is successfully created, take us to that drill details page

### DIFF
--- a/cypress/e2e/drill_creation.cy.js
+++ b/cypress/e2e/drill_creation.cy.js
@@ -16,7 +16,7 @@ describe('Drill Creation', () => {
 
     cy.get('button[type="submit"]').click();
 
-    cy.visit('/drills');
+    cy.url().should('include', '/drills/');
     cy.contains('Test Drill').should('exist');
   });
 

--- a/src/routes/drills/create/+page.svelte
+++ b/src/routes/drills/create/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { writable } from 'svelte/store';
+  import { goto } from '$app/navigation';
 
   let name = writable('');
   let brief_description = writable('');
@@ -63,12 +64,11 @@
       const data = await response.json();
       console.log('Response status:', response.status);
       console.log('Response body:', data);
-      // Handle successful submission
+      goto(`/drills/${data.id}`);
     } else {
       console.log('Response status:', response.status);
       const errorData = await response.json();
       console.log('Response body:', errorData);
-      // Handle error
     }
   }
 </script>


### PR DESCRIPTION
Redirect to drill details page after successful drill creation.

* **src/routes/drills/create/+page.svelte**
  - Import `goto` from `$app/navigation`.
  - Update `handleSubmit` function to redirect to the drill details page after successful drill creation using `goto`.

* **cypress/e2e/drill_creation.cy.js**
  - Update the drill creation test to verify redirection to the drill details page after successful drill creation.
  - Check that the URL includes `/drills/` after form submission.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill?shareId=2dd12244-174e-45be-81be-d7a47fb504b3).