### PR TITLE
Make the multi select buttons change colors when selected in drill creation

### DIFF
--- a/cypress/e2e/drill_creation.cy.js
+++ b/cypress/e2e/drill_creation.cy.js
@@ -29,4 +29,14 @@ describe('Drill Creation', () => {
     cy.get('select#skills_focused_on').should('have.css', 'border', '2px solid blue');
     cy.get('select#positions_focused_on').should('have.css', 'border', '2px solid blue');
   });
+
+  it('should change the color of multi-select buttons when selected', () => {
+    cy.visit('/drills/create');
+
+    cy.get('.skill-level-button').contains('Beginner').click();
+    cy.get('.skill-level-button').contains('Beginner').should('have.class', 'selected');
+
+    cy.get('.position-button').contains('Forward').click();
+    cy.get('.position-button').contains('Forward').should('have.class', 'selected');
+  });
 });

--- a/src/routes/drills/create/+page.svelte
+++ b/src/routes/drills/create/+page.svelte
@@ -106,6 +106,26 @@
       }
     });
   }
+
+  $: {
+    const skillLevelButtons = document.querySelectorAll('.skill-level-button');
+    skillLevelButtons.forEach(button => {
+      if ($skill_level.includes(button.textContent.toLowerCase())) {
+        button.classList.add('selected');
+      } else {
+        button.classList.remove('selected');
+      }
+    });
+
+    const positionButtons = document.querySelectorAll('.position-button');
+    positionButtons.forEach(button => {
+      if ($positions_focused_on.includes(button.textContent)) {
+        button.classList.add('selected');
+      } else {
+        button.classList.remove('selected');
+      }
+    });
+  }
 </script>
 
 <svelte:head>
@@ -141,11 +161,11 @@
     <div>
       <label for="skill_level" class="block text-sm font-medium text-gray-700">Appropriate for Skill Level:</label>
       <div class="flex flex-wrap gap-2 mt-1">
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skill_level, 'new to sport')}>New to Sport</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skill_level, 'beginner')}>Beginner</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skill_level, 'intermediate')}>Intermediate</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skill_level, 'advanced')}>Advanced</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skill_level, 'elite')}>Elite</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skill_level, 'new to sport')}>New to Sport</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skill_level, 'beginner')}>Beginner</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skill_level, 'intermediate')}>Intermediate</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skill_level, 'advanced')}>Advanced</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skill_level, 'elite')}>Elite</button>
       </div>
       {#if $errors.skill_level}
         <p class="error">{$errors.skill_level}</p>
@@ -211,11 +231,11 @@
     <div>
       <label for="skills_focused_on" class="block text-sm font-medium text-gray-700">Skills Focused On:</label>
       <div class="flex flex-wrap gap-2 mt-1">
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skills_focused_on, 'driving')}>Driving</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skills_focused_on, 'decision making')}>Decision Making</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skills_focused_on, 'catching')}>Catching</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skills_focused_on, 'throwing')}>Throwing</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(skills_focused_on, 'cardio')}>Cardio</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skills_focused_on, 'driving')}>Driving</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skills_focused_on, 'decision making')}>Decision Making</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skills_focused_on, 'catching')}>Catching</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skills_focused_on, 'throwing')}>Throwing</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 skill-level-button" on:click={() => toggleSelection(skills_focused_on, 'cardio')}>Cardio</button>
       </div>
       {#if $errors.skills_focused_on}
         <p class="error">{$errors.skills_focused_on}</p>
@@ -225,10 +245,10 @@
     <div>
       <label for="positions_focused_on" class="block text-sm font-medium text-gray-700">Positions Focused On:</label>
       <div class="flex flex-wrap gap-2 mt-1">
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(positions_focused_on, 'Beater')}>Beater</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(positions_focused_on, 'Chaser')}>Chaser</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(positions_focused_on, 'Keeper')}>Keeper</button>
-        <button type="button" class="px-3 py-1 rounded-full border border-gray-300" on:click={() => toggleSelection(positions_focused_on, 'Seeker')}>Seeker</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 position-button" on:click={() => toggleSelection(positions_focused_on, 'Beater')}>Beater</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 position-button" on:click={() => toggleSelection(positions_focused_on, 'Chaser')}>Chaser</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 position-button" on:click={() => toggleSelection(positions_focused_on, 'Keeper')}>Keeper</button>
+        <button type="button" class="px-3 py-1 rounded-full border border-gray-300 position-button" on:click={() => toggleSelection(positions_focused_on, 'Seeker')}>Seeker</button>
       </div>
       {#if $errors.positions_focused_on}
         <p class="error">{$errors.positions_focused_on}</p>

--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -107,3 +107,9 @@ button:focus:not(:focus-visible) {
 	width: 1px;
 	white-space: nowrap;
 }
+
+/* Add CSS rules to change the background color of multi-select buttons when selected */
+.selected {
+	background-color: var(--color-theme-1);
+	color: white;
+}


### PR DESCRIPTION
Add functionality to change the color of multi-select buttons when selected in drill creation.

* **CSS Changes:**
  - Add CSS rules in `src/routes/styles.css` to change the background color of multi-select buttons when selected using the `.selected` class.

* **Svelte Component Changes:**
  - Modify `src/routes/drills/create/+page.svelte` to apply the `.selected` class to multi-select buttons for skill levels and positions when selected.
  - Add reactive statements to update the class of the buttons based on the selected state.

* **Cypress Test Changes:**
  - Update `cypress/e2e/drill_creation.cy.js` to include tests verifying the color change of multi-select buttons when selected.
  - Use `should('have.class', 'selected')` to check if the button has the `.selected` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austeane/qdrill?shareId=2c74d105-4245-439e-ba01-75a549ce8be2).