### PR TITLE
Fix drill variation link

### DIFF
--- a/src/routes/drills/[id]/+page.svelte
+++ b/src/routes/drills/[id]/+page.svelte
@@ -88,9 +88,10 @@
 	}
 
 	// Function to create a new variation
-	async function createVariation() {
-		await goto(`/drills/create?parentId=${drill.id}`);
-	}
+       async function createVariation() {
+               // Use the current drill ID from the store
+               await goto(`/drills/create?parentId=${$drill.id}`);
+       }
 
 	async function loadPotentialParents() {
 		isLoadingParents = true;


### PR DESCRIPTION
## Summary
- fix `createVariation` to read the drill ID from the store

## Testing
- `pnpm test` *(fails: unable to download pnpm)*
- `pnpm lint` *(fails: unable to download pnpm)*