### PR TITLE
Add reusable EmptyState component

### DIFF
--- a/src/lib/components/EmptyState.svelte
+++ b/src/lib/components/EmptyState.svelte
@@ -1,0 +1,99 @@
+<script>
+	export let title = 'No results found';
+	export let description = '';
+	export let icon = 'search'; // search, drills, plans, formations
+	export let actions = []; // Array of action objects: { label, href, onClick, primary }
+	export let showSearchSuggestion = false;
+</script>
+
+<div class="flex flex-col items-center justify-center py-12 px-4">
+	<!-- Icon -->
+	<div class="w-16 h-16 mb-4 text-gray-400">
+		{#if icon === 'search'}
+			<svg class="w-full h-full" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="1.5"
+					d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+				/>
+			</svg>
+		{:else if icon === 'drills'}
+			<svg class="w-full h-full" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="1.5"
+					d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+				/>
+			</svg>
+		{:else if icon === 'plans'}
+			<svg class="w-full h-full" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8v4l3 3" />
+				<circle cx="12" cy="12" r="9" stroke-width="1.5" />
+			</svg>
+		{:else if icon === 'formations'}
+			<svg class="w-full h-full" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="1.5"
+					d="M16 7V3M8 7V3M12 17v4m0-4v4m0-10V3M3 7h18M5 10h14M7 13h10"
+				/>
+			</svg>
+		{/if}
+	</div>
+
+	<!-- Title and Description -->
+	<h3 class="text-lg font-semibold text-gray-900 mb-2">{title}</h3>
+	{#if description}
+		<p class="text-gray-600 text-center max-w-md mb-6">{description}</p>
+	{/if}
+
+	<!-- Search Suggestions -->
+	{#if showSearchSuggestion}
+		<div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6 max-w-md">
+			<h4 class="font-medium text-blue-900 mb-2">Try adjusting your search:</h4>
+			<ul class="text-sm text-blue-800 space-y-1">
+				<li>&bull; Remove some filters</li>
+				<li>&bull; Try different keywords</li>
+				<li>&bull; Check your spelling</li>
+			</ul>
+		</div>
+	{/if}
+
+	<!-- Actions -->
+	{#if actions.length > 0}
+		<div class="flex flex-wrap gap-3 justify-center">
+			{#each actions as action}
+				{#if action.href}
+					<a
+						href={action.href}
+						class="px-4 py-2 rounded-md font-medium transition-colors duration-200"
+						class:bg-blue-600={action.primary}
+						class:text-white={action.primary}
+						class:hover:bg-blue-700={action.primary}
+						class:bg-gray-100={!action.primary}
+						class:text-gray-700={!action.primary}
+						class:hover:bg-gray-200={!action.primary}
+					>
+						{action.label}
+					</a>
+				{:else if action.onClick}
+					<button
+						on:click={action.onClick}
+						class="px-4 py-2 rounded-md font-medium transition-colors duration-200"
+						class:bg-blue-600={action.primary}
+						class:text-white={action.primary}
+						class:hover:bg-blue-700={action.primary}
+						class:bg-gray-100={!action.primary}
+						class:text-gray-700={!action.primary}
+						class:hover:bg-gray-200={!action.primary}
+					>
+						{action.label}
+					</button>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/routes/formations/+page.svelte
+++ b/src/routes/formations/+page.svelte
@@ -21,6 +21,7 @@
 		selectedSortOrder, // Added (from store)
 		resetFormationFilters // Added helper
 	} from '$lib/stores/formationsStore';
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { slide } from 'svelte/transition'; // Keep for potential sort dropdown
 
 	export let data;
@@ -132,6 +133,16 @@
 		{ value: 'formation_type', label: 'Type' }
 	];
 
+	$: hasFilters =
+		$searchQuery ||
+		Object.keys($selectedTags).some((key) => $selectedTags[key]) ||
+		$selectedFormationType;
+
+	$: emptyStateActions = [
+		{ label: 'View All Formations', onClick: () => goto('/formations'), primary: true },
+		{ label: 'Create Formation', href: '/formations/create' }
+	];
+
 	function toggleSortOptions(event) {
 		event.stopPropagation();
 		showSortOptions = !showSortOptions;
@@ -149,7 +160,7 @@
 	// Close dropdown on click outside
 	import { onMount } from 'svelte'; // Keep onMount for this
 	import TitleWithTooltip from '$lib/components/TitleWithTooltip.svelte';
-	
+
 	onMount(() => {
 		const handleClickOutside = (event) => {
 			if (sortOptionsRef && !sortOptionsRef.contains(event.target)) {
@@ -326,18 +337,12 @@
 		</div>
 		<!-- Empty State -->
 	{:else if !$formations || $formations.length === 0}
-		<div class="bg-white rounded-lg shadow-sm p-8 text-center">
-			<h3 class="text-xl font-medium text-gray-800 mb-2">No formations found</h3>
-			<p class="text-gray-600 mb-4">
-				Try adjusting your search or filters, or create a new formation.
-			</p>
-			<button
-				class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-md"
-				on:click={() => goto('/formations/create')}
-			>
-				Create Formation
-			</button>
-		</div>
+		<EmptyState
+			title="No formations found"
+			description="Explore our collection of quadball formations or contribute your own."
+			icon="formations"
+			actions={emptyStateActions}
+		/>
 		<!-- Formations Grid -->
 	{:else}
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -349,12 +354,9 @@
 					class="block bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
 				>
 					<div class="p-6">
-						<h2
-							data-testid="formation-card-name"
-							class="text-xl font-semibold text-gray-800 mb-2"
-						>
-							<TitleWithTooltip 
-								title={formation.name} 
+						<h2 data-testid="formation-card-name" class="text-xl font-semibold text-gray-800 mb-2">
+							<TitleWithTooltip
+								title={formation.name}
 								className="text-xl font-semibold text-gray-800"
 								maxWidth="100%"
 							/>


### PR DESCRIPTION
## Summary
- create `EmptyState.svelte` for consistent empty states
- integrate EmptyState into drills, practice plans and formations pages

## Testing
- `pnpm run lint` *(fails: Code style issues found)*
- `pnpm run test` *(fails: 8 test files failed)*