### PR TITLE
Add skeleton loaders across pages

### DIFF
--- a/src/lib/components/FilterPanel.svelte
+++ b/src/lib/components/FilterPanel.svelte
@@ -28,13 +28,23 @@
 		selectedEstimatedParticipantsMax,
 		updateFilterState as updatePracticePlanFilterState
 	} from '$lib/stores/practicePlanFilterStore';
-	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
-	import { browser } from '$app/environment';
-	import debounce from 'lodash/debounce';
-	import { Plus, Minus, Search } from 'lucide-svelte';
+        import { page } from '$app/stores';
+        import { goto } from '$app/navigation';
+        import { browser } from '$app/environment';
+        import debounce from 'lodash/debounce';
+        import { Plus, Minus, Search } from 'lucide-svelte';
+        import { createLoadingState } from '$lib/utils/loadingStates.js';
+        import Spinner from '$lib/components/Spinner.svelte';
 
-	const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
+
+const filterApplying = createLoadingState();
+
+function handleFilterChangeWithLoading() {
+        filterApplying.start();
+                handleFilterChangeWithLoading();
+        setTimeout(() => filterApplying.stop(), 1000);
+}
 
 	export let customClass = '';
 	export let filterType = 'drills'; // New prop to determine filter context
@@ -135,8 +145,8 @@
 			selectedEstimatedParticipantsMax.set(100);
 			selectedDrills = [];
 		}
-		closeAllFilters();
-		dispatch('filterChange');
+                closeAllFilters();
+                handleFilterChangeWithLoading();
 	}
 
 	// Function to handle toggling filters
@@ -319,7 +329,7 @@
 			}
 			return updated;
 		});
-		dispatch('filterChange');
+                        handleFilterChangeWithLoading();
 	}
 
 	// Helper function for updating DRILL filter states
@@ -334,7 +344,7 @@
 				}
 				return updated;
 			});
-			dispatch('filterChange');
+                handleFilterChangeWithLoading();
 		};
 	}
 
@@ -350,20 +360,20 @@
 	function handleEstimatedParticipantsChange(event) {
 		selectedEstimatedParticipantsMin.set(estimatedParticipantsRange[0]);
 		selectedEstimatedParticipantsMax.set(estimatedParticipantsRange[1]);
-		dispatch('filterChange');
+                handleFilterChangeWithLoading();
 	}
 
 	// Update the range slider handlers
 	function handleNumberOfPeopleChange(event) {
 		selectedNumberOfPeopleMin.set(numberOfPeopleRange[0]);
 		selectedNumberOfPeopleMax.set(numberOfPeopleRange[1]);
-		dispatch('filterChange');
+                handleFilterChangeWithLoading();
 	}
 
 	function handleSuggestedLengthsChange(event) {
 		selectedSuggestedLengthsMin.set(suggestedLengthsRange[0]);
 		selectedSuggestedLengthsMax.set(suggestedLengthsRange[1]);
-		dispatch('filterChange');
+                handleFilterChangeWithLoading();
 	}
 
 	let skillsSearchTerm = '';
@@ -387,7 +397,7 @@
 	// Helper to toggle tri‑state boolean filters (null → true → false → null)
 	function toggleBooleanFilter(store) {
 		store.update((current) => (current === null ? true : current === true ? false : null));
-		dispatch('filterChange');
+                handleFilterChangeWithLoading();
 	}
 
 	function toggleHasVideo() {
@@ -405,6 +415,14 @@
 
 <!-- Filter Buttons -->
 <div class={`flex flex-wrap gap-2 mb-4 relative ${customClass}`} on:keydown={handleKeydown}>
+        {#if $filterApplying}
+                <div class="absolute inset-0 bg-white bg-opacity-75 flex items-center justify-center z-20">
+                        <div class="flex items-center space-x-2">
+                                <Spinner size="sm" color="blue" />
+                                <span class="text-sm text-gray-600">Applying filters...</span>
+                        </div>
+                </div>
+        {/if}
 	<!-- Drills Filters -->
 	{#if filterType === 'drills' && (skillLevels.length || complexities.length || skillsFocusedOn.length || positionsFocusedOn.length || numberOfPeopleOptions.min !== null || numberOfPeopleOptions.max !== null || suggestedLengths.min !== null || suggestedLengths.max !== null || $selectedHasVideo || $selectedHasDiagrams || $selectedHasImages)}
 		<!-- Skill Levels Filter -->

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -1,6 +1,7 @@
 <script>
-	import { createEventDispatcher } from 'svelte';
-	import { navigating } from '$app/stores'; // Import navigating store if needed for disabling
+        import { createEventDispatcher } from 'svelte';
+        import { navigating } from '$app/stores';
+        import LoadingButton from '$lib/components/ui/button/LoadingButton.svelte';
 
 	export let currentPage = 1;
 	export let totalPages = 1;
@@ -24,24 +25,28 @@
 
 {#if totalPages > 1}
 	<div class="flex justify-center items-center mt-8 space-x-4" data-testid="pagination-controls">
-		<button
-			on:click={prevPage}
-			disabled={currentPage === 1 || $navigating}
-			class="px-4 py-2 bg-gray-200 text-gray-700 rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-300 transition-colors duration-300"
-			data-testid="pagination-prev-button"
-		>
-			Previous
-		</button>
+                <LoadingButton
+                        loading={$navigating}
+                        on:click={prevPage}
+                        disabled={currentPage === 1}
+                        variant="outline"
+                        size="sm"
+                        data-testid="pagination-prev-button"
+                >
+                        Previous
+                </LoadingButton>
 		<span class="text-gray-700" data-testid="pagination-current-page"
 			>Page {currentPage} of {totalPages}</span
 		>
-		<button
-			on:click={nextPage}
-			disabled={currentPage === totalPages || $navigating}
-			class="px-4 py-2 bg-gray-200 text-gray-700 rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-300 transition-colors duration-300"
-			data-testid="pagination-next-button"
-		>
-			Next
-		</button>
+                <LoadingButton
+                        loading={$navigating}
+                        on:click={nextPage}
+                        disabled={currentPage === totalPages}
+                        variant="outline"
+                        size="sm"
+                        data-testid="pagination-next-button"
+                >
+                        Next
+                </LoadingButton>
 	</div>
 {/if}

--- a/src/lib/components/SkeletonLoader.svelte
+++ b/src/lib/components/SkeletonLoader.svelte
@@ -1,21 +1,50 @@
 <script>
-	export let lines = 3;
-	export let showAvatar = false;
-	export let className = '';
+  export let lines = 3;
+  export let showAvatar = false;
+  export let showButton = false;
+  export let showCard = false;
+  export let className = '';
+  export let height = 'auto';
 </script>
 
-<div class="animate-pulse {className}">
-	{#if showAvatar}
-		<div class="flex items-center space-x-4 mb-4">
-			<div class="rounded-full bg-gray-300 h-10 w-10"></div>
-			<div class="flex-1 space-y-2">
-				<div class="h-4 bg-gray-300 rounded w-3/4"></div>
-				<div class="h-4 bg-gray-300 rounded w-1/2"></div>
-			</div>
-		</div>
-	{/if}
-	
-	{#each Array(lines) as _, i}
-		<div class="h-4 bg-gray-300 rounded mb-2 {i === lines - 1 ? 'w-2/3' : 'w-full'}"></div>
-	{/each}
-</div> 
+<div class="animate-pulse {className}" style="height: {height}">
+  {#if showCard}
+    <div class="border border-gray-200 rounded-lg p-6 bg-white">
+      {#if showAvatar}
+        <div class="flex items-center space-x-4 mb-4">
+          <div class="rounded-full bg-gray-300 h-10 w-10"></div>
+          <div class="flex-1 space-y-2">
+            <div class="h-4 bg-gray-300 rounded w-3/4"></div>
+            <div class="h-4 bg-gray-300 rounded w-1/2"></div>
+          </div>
+        </div>
+      {/if}
+
+      {#each Array(lines) as _, i}
+        <div class="h-4 bg-gray-300 rounded mb-2 {i === lines - 1 ? 'w-2/3' : 'w-full'}"></div>
+      {/each}
+
+      {#if showButton}
+        <div class="h-10 bg-gray-300 rounded w-full mt-4"></div>
+      {/if}
+    </div>
+  {:else}
+    {#if showAvatar}
+      <div class="flex items-center space-x-4 mb-4">
+        <div class="rounded-full bg-gray-300 h-10 w-10"></div>
+        <div class="flex-1 space-y-2">
+          <div class="h-4 bg-gray-300 rounded w-3/4"></div>
+          <div class="h-4 bg-gray-300 rounded w-1/2"></div>
+        </div>
+      </div>
+    {/if}
+
+    {#each Array(lines) as _, i}
+      <div class="h-4 bg-gray-300 rounded mb-2 {i === lines - 1 ? 'w-2/3' : 'w-full'}"></div>
+    {/each}
+
+    {#if showButton}
+      <div class="h-10 bg-gray-300 rounded w-full mt-4"></div>
+    {/if}
+  {/if}
+</div>

--- a/src/routes/formations/+page.svelte
+++ b/src/routes/formations/+page.svelte
@@ -1,8 +1,9 @@
 <script>
 	// import { onMount } from 'svelte'; // Removed
 	import { applyAction, enhance } from '$app/forms';
-	import { goto } from '$app/navigation';
-	import { navigating } from '$app/stores';
+import { goto } from '$app/navigation';
+import { navigating } from '$app/stores';
+import SkeletonLoader from '$lib/components/SkeletonLoader.svelte';
 	import { page } from '$app/stores';
 	import {
 		formations,
@@ -320,11 +321,13 @@
 	</div>
 
 	<!-- Loading State -->
-	{#if $navigating}
-		<div class="flex justify-center py-12">
-			<div class="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
-		</div>
-		<!-- Empty State -->
+{#if $navigating}
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {#each Array(6) as _}
+                                <SkeletonLoader showCard lines={3} />
+                        {/each}
+                </div>
+                <!-- Empty State -->
 	{:else if !$formations || $formations.length === 0}
 		<div class="bg-white rounded-lg shadow-sm p-8 text-center">
 			<h3 class="text-xl font-medium text-gray-800 mb-2">No formations found</h3>

--- a/src/routes/practice-plans/+page.svelte
+++ b/src/routes/practice-plans/+page.svelte
@@ -2,8 +2,8 @@
 	import FilterPanel from '$lib/components/FilterPanel.svelte';
 	import { onDestroy, onMount, afterUpdate } from 'svelte';
 	import { tick } from 'svelte';
-	import { goto } from '$app/navigation';
-	import { page } from '$app/stores';
+        import { goto } from '$app/navigation';
+        import { page, navigating } from '$app/stores';
 	import debounce from 'lodash/debounce';
 	import { selectedSortOption, selectedSortOrder } from '$lib/stores/sortStore';
 	import UpvoteDownvote from '$lib/components/UpvoteDownvote.svelte';
@@ -15,7 +15,8 @@
 		selectedEstimatedParticipantsMax
 	} from '$lib/stores/practicePlanFilterStore';
 	import DeletePracticePlan from '$lib/components/DeletePracticePlan.svelte';
-	import Pagination from '$lib/components/Pagination.svelte';
+        import Pagination from '$lib/components/Pagination.svelte';
+        import SkeletonLoader from '$lib/components/SkeletonLoader.svelte';
 	import { cart } from '$lib/stores/cartStore';
 	import AiPlanGeneratorModal from '$lib/components/practice-plan/AiPlanGeneratorModal.svelte';
 	import TitleWithTooltip from '$lib/components/TitleWithTooltip.svelte';
@@ -306,9 +307,25 @@
 		</div>
 	{/if}
 
-	<!-- Practice Plans Grid -->
-	{#if practicePlans.length > 0}
-		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <!-- Practice Plans Grid -->
+        {#if $navigating && practicePlans.length === 0}
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {#each Array(6) as _}
+                                <div class="bg-white rounded-lg shadow-md p-6">
+                                        <div class="flex items-center space-x-3 mb-4">
+                                                <div class="w-8 h-8 bg-gray-300 rounded"></div>
+                                                <SkeletonLoader lines={1} className="flex-1" />
+                                        </div>
+                                        <SkeletonLoader lines={3} className="mb-4" />
+                                        <div class="flex justify-between items-center">
+                                                <div class="h-4 bg-gray-300 rounded w-16"></div>
+                                                <div class="h-8 bg-gray-300 rounded w-20"></div>
+                                        </div>
+                                </div>
+                        {/each}
+                </div>
+        {:else if practicePlans.length > 0}
+                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
 			<!-- Use practicePlans directly (already paginated and sorted by server) -->
 			{#each practicePlans as plan (plan.id)}
 				<div


### PR DESCRIPTION
## Summary
- enhance `SkeletonLoader` component with card and button options
- show loading overlay in `FilterPanel`
- switch `Pagination` buttons to `LoadingButton`
- add filter and search loading states on drills page
- implement skeleton loaders for drills, practice plans, and formations pages

## Testing
- `pnpm test` *(fails: DatabaseError, etc.)*
- `pnpm lint` *(fails: 302 problems)*