### PR TITLE
Update ticket 30 documentation

### DIFF
--- a/tickets/30-cleanup-dead-code-api.md
+++ b/tickets/30-cleanup-dead-code-api.md
@@ -2,15 +2,18 @@
 
 **Priority:** Low
 
-**Description:** Some API routes and potentially their corresponding SvelteKit pages appear to be unused or relate to features (like feedback) that are not currently implemented or used.
+**Description:** Earlier code review notes suggested there were unused API routes for a feedback feature and for one-off drill diagram migrations. The repository has since evolved:
 
-**Affected Files:**
+- The feedback feature is **implemented**. The global `FeedbackButton` and `FeedbackModal` components use the `/api/feedback` endpoints, and there is a `/feedback` page served by `+page.svelte` and `+page.server.js`.
+- The diagram migration utilities (`migrate-diagrams` and `test-migration`) and their helper (`diagramMigration.js`) have already been removed.
 
-- `src/routes/api/feedback/**` (All routes: [`/+server.js`](src/routes/api/feedback/+server.js), [`/[id]/delete/+server.js`](src/routes/api/feedback/[id]/delete/+server.js), [`/[id]/upvote/+server.js`](src/routes/api/feedback/[id]/upvote/+server.js))
-- `src/routes/feedback/**` (Corresponding page: [`+page.svelte`](src/routes/feedback/+page.svelte), [`+page.server.js`](src/routes/feedback/+page.server.js))
-- [`src/routes/api/drills/migrate-diagrams/+server.js`](src/routes/api/drills/migrate-diagrams/+server.js) (One-off migration utility)
-- [`src/routes/api/drills/test-migration/+server.js`](src/routes/api/drills/test-migration/+server.js) (Migration testing utility)
-- Potentially others if broader dead code analysis reveals them.
+This ticket now serves as documentation that the migration code cleanup is complete and that the feedback endpoints are active, not dead code.
+
+**Affected Files (previously identified):**
+
+- `src/routes/api/feedback/**` and `src/routes/feedback/**` – these are now confirmed in use.
+- `src/routes/api/drills/migrate-diagrams/+server.js` – **removed**.
+- `src/routes/api/drills/test-migration/+server.js` – **removed**.
 
 **Related Notes:**
 
@@ -21,6 +24,6 @@
 
 **Action Required:**
 
-1.  Confirm the feedback feature is not implemented/used. If so, delete the `src/routes/api/feedback/` directory and the `src/routes/feedback/` directory.
-2.  Confirm the diagram migration is complete. If so, delete [`src/routes/api/drills/migrate-diagrams/+server.js`](src/routes/api/drills/migrate-diagrams/+server.js) and [`src/routes/api/drills/test-migration/+server.js`](src/routes/api/drills/test-migration/+server.js) (along with the utility function [`src/lib/utils/diagramMigration.js`](src/lib/utils/diagramMigration.js) as per Ticket 29).
-3.  Review other potentially unused API endpoints or pages.
+1.  No further action for the migration utilities—they have already been deleted.
+2.  Ensure the feedback API routes remain protected and maintain any database schema required for them.
+3.  Continue to monitor for any other unused API routes or pages and remove them as discovered.


### PR DESCRIPTION
## Summary
- update ticket #30 to reflect removed migration utilities
- clarify feedback API and page are live and in use

## Testing
- `pnpm test` *(fails: formationService and userService tests)*

------
https://chatgpt.com/codex/tasks/task_e_687a8dc8d3c0832595ac990030cf0c5e