### PR TITLE
Update group filter ticket

### DIFF
--- a/tickets/practice-plan-position-filter-view.md
+++ b/tickets/practice-plan-position-filter-view.md
@@ -9,6 +9,14 @@
 - Schema: `src/lib/validation/practicePlanSchema.ts`
 - Database: `practice_plan_drills` table (uses `parallel_timeline` field)
 
+### Current Code Status
+
+The app currently implements a **PositionFilter** component (`src/lib/components/practice-plan/PositionFilter.svelte`).
+This filter lets users toggle between the three preset positions **CHASERS**, **BEATERS**, and **SEEKERS**.
+`+page.svelte` applies the filter using `filterSectionsByPositions()` to hide or flatten parallel groups.
+Group badges on cards also use hardcoded position colors. The system does not yet detect arbitrary
+`parallel_timeline` values, so custom group names are ignored.
+
 ## Problem Statement
 
 Current practice plans show all activities linearly, making it difficult to:


### PR DESCRIPTION
## Summary
- clarify what already exists in practice-plan position filter ticket

## Testing
- `pnpm test:unit:run` *(fails: Cannot read properties of null (reading 'id'))*

------
https://chatgpt.com/codex/tasks/task_e_687a8dd90d8c8325a48faa5707d3fc82