### PR TITLE
Update ticket 28 dead code stores

### DIFF
--- a/tickets/28-cleanup-dead-code-stores.md
+++ b/tickets/28-cleanup-dead-code-stores.md
@@ -2,13 +2,12 @@
 
 **Priority:** Low
 
-**Description:** The codebase contains Svelte stores or parts of stores that are either entirely unused or have unused sections, indicating dead code or incomplete features. Removing them simplifies state management and improves clarity.
+**Description:** Earlier reviews flagged a few stores as unused. The old `dragStore.js` file has already been removed and `feedbackStore.js` now only contains a `feedbackModalVisible` writable. The `selectedItems` store mentioned in older notes no longer exists in `sectionsStore.js`. We should ensure there are no lingering references and continue checking for other dead store code.
 
 **Affected Files:**
 
-- [`src/lib/stores/dragStore.js`](src/lib/stores/dragStore.js) (Appears completely unused)
-- [`src/lib/stores/feedbackStore.js`](src/lib/stores/feedbackStore.js) (The `feedbackList` writable seems unused)
-- Potentially others (e.g., `selectedItems` in [`sectionsStore.js`](src/lib/stores/sectionsStore.js) requires verification).
+- [`src/lib/stores/feedbackStore.js`](src/lib/stores/feedbackStore.js) – contains only `feedbackModalVisible`.
+- Potentially others in [`src/lib/stores`](src/lib/stores/) if unused exports remain.
 
 **Related Notes:**
 
@@ -18,8 +17,6 @@
 
 **Action Required:**
 
-1.  Verify that [`src/lib/stores/dragStore.js`](src/lib/stores/dragStore.js) has no imports or references throughout the codebase.
-2.  If unused, delete the `dragStore.js` file.
-3.  Verify that `$feedbackList` from [`src/lib/stores/feedbackStore.js`](src/lib/stores/feedbackStore.js) is not used. If confirmed, remove the `feedbackList` writable from the store.
-4.  Investigate the usage of `$selectedItems` in [`src/lib/stores/sectionsStore.js`](src/lib/stores/sectionsStore.js). If it's unused, remove it.
-5.  Conduct a broader search for other potentially unused store variables or entire store files.
+1.  Search the repo for any remaining references to the deleted `dragStore` or the removed `feedbackList` variable and clean them up.
+2.  Audit [`src/lib/stores`](src/lib/stores/) for any stores or exports that are never imported elsewhere.
+3.  Remove any confirmed unused store files or variables.


### PR DESCRIPTION
## Summary
- update ticket 28 to note that `dragStore.js` and `feedbackList` are gone
- clarify remaining audit steps for unused stores

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687a8db551688325b2bb92f10c83a463