### PR TITLE
Add practice plan wrapper scripts

### DIFF
--- a/create_drill_script.py
+++ b/create_drill_script.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Simple helper to create drills via the QDrill API.
+
+Edit the DRILLS_TO_CREATE list with one or more drill objects matching
+`createDrillSchema` and run `python create_drill_script.py`.
+The script posts each drill to the API and prints the created ID.
+"""
+
+import os
+import json
+import sys
+
+try:
+    import requests
+except ModuleNotFoundError:
+    sys.exit("The 'requests' package is required. Install with: pip install requests")
+
+API_URL = os.environ.get("QDRILL_API_URL", "http://localhost:3000/api/drills")
+
+# Example data - replace with real drills
+DRILLS_TO_CREATE = [
+    {
+        "name": "Example Drill",
+        "brief_description": "Update this drill data before running",
+        "visibility": "public",
+        "is_editable_by_others": True,
+    }
+]
+
+
+def create_drill(drill):
+    try:
+        response = requests.post(API_URL, json=drill)
+        response.raise_for_status()
+        data = response.json()
+        print(f"\u2713 Created drill '{data.get('name')}' (ID: {data.get('id')})")
+        return data
+    except requests.RequestException as e:
+        print(f"\u2717 Failed to create '{drill.get('name')}' : {e}")
+        if hasattr(e, 'response') and e.response is not None:
+            print(e.response.text)
+        return None
+
+
+def main():
+    print(f"Posting {len(DRILLS_TO_CREATE)} drill(s) to {API_URL}")
+    results = [create_drill(d) for d in DRILLS_TO_CREATE]
+    # Save created drill info for reference
+    with open("created_drills.json", "w") as f:
+        json.dump([r for r in results if r], f, indent=2)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/create_practice_plan_script.py
+++ b/create_practice_plan_script.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Helper script to create a practice plan via the QDrill API.
+
+Update PRACTICE_PLAN_DATA with your plan information matching
+`createPracticePlanSchema` and run `python create_practice_plan_script.py`.
+"""
+
+import os
+import json
+import sys
+
+try:
+    import requests
+except ModuleNotFoundError:
+    sys.exit("The 'requests' package is required. Install with: pip install requests")
+
+API_URL = os.environ.get("QDRILL_API_URL", "http://localhost:3000/api/practice-plans")
+
+# Minimal example plan - replace with real data
+PRACTICE_PLAN_DATA = {
+    "name": "Example Practice Plan",
+    "visibility": "public",
+    "is_editable_by_others": True,
+    "sections": [
+        {
+            "name": "Example Section",
+            "order": 0,
+            "items": [
+                {
+                    "type": "break",
+                    "name": "Placeholder",
+                    "duration": 5
+                }
+            ]
+        }
+    ]
+}
+
+
+def create_plan(plan):
+    try:
+        response = requests.post(API_URL, json=plan)
+        response.raise_for_status()
+        data = response.json()
+        print(f"\u2713 Created practice plan '{data.get('id')}': {data.get('message')}")
+        return data
+    except requests.RequestException as e:
+        print(f"\u2717 Failed to create practice plan: {e}")
+        if hasattr(e, 'response') and e.response is not None:
+            print(e.response.text)
+        return None
+
+
+def main():
+    print(f"Posting practice plan to {API_URL}")
+    result = create_plan(PRACTICE_PLAN_DATA)
+    if result:
+        with open("created_practice_plan.json", "w") as f:
+            json.dump(result, f, indent=2)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tickets/llm-practice-plan-tools.md
+++ b/tickets/llm-practice-plan-tools.md
@@ -32,14 +32,14 @@
       ```
     - If the returned list is empty, the LLM can proceed to use `create_drill`.
 
-2.  **[DONE - Implemented via Script] `create_drill(drill_data: object)` Tool:**
+2.  **[DONE] `create_drill(drill_data: object)` Tool:**
 
     - **Purpose:** Create a new drill when one doesn't exist.
-    - **Underlying API:** `POST /api/drills`.
-    - **Implementation:** This action is currently performed by asking the user to run the `create_drill_script.py` script located in the project root. This script handles calling the API with the correct data format.
-    - **Usage Guide:** See `docs/guides/llm_creating_drills.md` for detailed instructions on how to prepare data, update the script, ask the user to run it, and verify the results.
+    - **Underlying API:** `POST /api/drills` (implemented in `src/routes/api/drills/+server.js`).
+      - Incoming data is validated with `createDrillSchema` and persisted via `drillService.createDrill`.
+    - **Implementation:** Wrapper script `create_drill_script.py` posts JSON data matching `createDrillSchema` to the API. Edit the `DRILLS_TO_CREATE` list and run `python create_drill_script.py`.
 
-3.  **[Ready for Implementation] `create_practice_plan(plan_data: object)` Tool:**
+3.  **[DONE] `create_practice_plan(plan_data: object)` Tool:**
     - **Purpose:** Create the entire practice plan structure, including metadata, sections, and items (linking to existing or newly created drills).
     - **Underlying API:** `POST /api/practice-plans`.
       - The endpoint uses `createPracticePlanSchema` (Zod schema located in `src/lib/validation/practicePlanSchema.ts`) for validation.
@@ -47,6 +47,6 @@
     - **Input:** `plan_data` (object): A nested JSON object representing the entire plan, conforming to `createPracticePlanSchema`. Requires top-level metadata (`name`) and at least one section containing at least one item.
       - See `createPracticePlanSchema` in `src/lib/validation/practicePlanSchema.ts` for the exact expected structure and fields for the plan, sections, and items.
     - **Output:** `{id: number, message: string}`: Object containing the ID of the newly created practice plan and a success message.
-    - **Status:** The existing API endpoint and service layer **already support** the required nested creation functionality. No backend changes are needed.
+    - **Implementation:** Wrapper script `create_practice_plan_script.py` sends a full practice plan object to the API. Edit `PRACTICE_PLAN_DATA` and run `python create_practice_plan_script.py`.
 
 By building these tools, the LLM can interact with the application safely and efficiently, leveraging the existing robust backend logic.


### PR DESCRIPTION
## Summary
- document wrapper scripts in `llm-practice-plan-tools` ticket
- add `create_drill_script.py` helper for posting drills to the API
- add `create_practice_plan_script.py` helper for posting practice plans

## Testing
- `pnpm test:unit:run` *(fails: DatabaseError, ForbiddenError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687a8dd5c904832585114620c2fef008