### PR TITLE
Implement practice plan form ticket

### DIFF
--- a/src/lib/components/practice-plan/PracticePlanActions.svelte
+++ b/src/lib/components/practice-plan/PracticePlanActions.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { undo, redo, canUndo, canRedo } from '$lib/stores/historyStore';
+  import { totalPlanDuration, startTime } from '$lib/stores/sectionsStore';
+  import { formatTime } from '$lib/utils/timeUtils';
+</script>
+
+<div class="bg-blue-50 p-4 rounded-lg shadow-sm flex justify-between items-center">
+  <div>
+    <h2 class="font-semibold text-blue-800">Practice Duration</h2>
+    <p class="text-blue-600">Start: {formatTime($startTime)} • Total: {$totalPlanDuration} minutes</p>
+    <p class="text-xs text-blue-500 mt-1">Keyboard shortcuts: Ctrl+Z (Undo), Ctrl+Shift+Z (Redo)</p>
+  </div>
+  <div class="flex items-center gap-4">
+    <Button variant="outline" size="icon" on:click={undo} disabled={!$canUndo} title="Undo">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
+      </svg>
+    </Button>
+    <Button variant="outline" size="icon" on:click={redo} disabled={!$canRedo} title="Redo">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m15 15 6-6m0 0-6-6m6 6H9a6 6 0 0 0 0 12h3" />
+      </svg>
+    </Button>
+    <div class="text-3xl font-bold text-blue-700">{$totalPlanDuration}m</div>
+  </div>
+</div>

--- a/src/lib/components/practice-plan/PracticePlanSectionsEditor.svelte
+++ b/src/lib/components/practice-plan/PracticePlanSectionsEditor.svelte
@@ -1,0 +1,48 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import {
+    sections,
+    addSection,
+    removeSection,
+    removeItem,
+    handleDurationChange,
+    handleTimelineChange,
+    handleUngroup,
+    getTimelineName,
+    customTimelineNames
+  } from '$lib/stores/sectionsStore';
+  import SectionContainer from '$lib/components/practice-plan/sections/SectionContainer.svelte';
+  import SimpleButton from '../../routes/practice-plans/components/SimpleButton.svelte';
+
+  const dispatch = createEventDispatcher();
+
+  function handleOpenDrillSearch(event) {
+    dispatch('openDrillSearch', event.detail);
+  }
+
+  function handleOpenTimelineSelector() {
+    dispatch('openTimelineSelector');
+  }
+</script>
+
+<div class="practice-plan-sections space-y-4">
+  <h2 class="text-xl font-semibold">Plan Sections &amp; Items</h2>
+  {#each $sections as section, sectionIndex}
+    <SectionContainer
+      {section}
+      {sectionIndex}
+      on:openDrillSearch={handleOpenDrillSearch}
+      on:openTimelineSelector={handleOpenTimelineSelector}
+      onRemoveSection={removeSection}
+      onRemoveItem={removeItem}
+      onDurationChange={handleDurationChange}
+      onTimelineChange={handleTimelineChange}
+      onUngroup={handleUngroup}
+      timelineNameGetter={getTimelineName}
+      customTimelineNamesData={$customTimelineNames}
+    />
+  {/each}
+  <div class="my-4">
+    <SimpleButton on:click={addSection}>+ Add Section</SimpleButton>
+  </div>
+</div>

--- a/src/lib/utils/actions/practicePlanAuthHandler.js
+++ b/src/lib/utils/actions/practicePlanAuthHandler.js
@@ -1,0 +1,43 @@
+import { page } from '$app/stores';
+import { get } from 'svelte/store';
+import { signIn } from '$lib/auth-client';
+
+/**
+ * Svelte action to intercept practice plan form submission when the
+ * user is not authenticated. It saves the plan data via the pending
+ * plans API and then triggers the sign-in flow.
+ */
+export function practicePlanAuthHandler(form) {
+  async function handleSubmit(event) {
+    const session = get(page).data?.session;
+    if (!session) {
+      event.preventDefault();
+      const formData = new FormData(form);
+      const obj = {};
+      for (const [key, value] of formData.entries()) {
+        if (obj[key]) {
+          if (!Array.isArray(obj[key])) obj[key] = [obj[key]];
+          obj[key].push(value);
+        } else {
+          obj[key] = value;
+        }
+      }
+      try {
+        await fetch('/api/pending-plans', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(obj)
+        });
+      } catch (err) {
+        console.error('Failed to save pending plan', err);
+      }
+      signIn.social({ provider: 'google' });
+    }
+  }
+  form.addEventListener('submit', handleSubmit);
+  return {
+    destroy() {
+      form.removeEventListener('submit', handleSubmit);
+    }
+  };
+}

--- a/src/routes/practice-plans/PracticePlanForm.svelte
+++ b/src/routes/practice-plans/PracticePlanForm.svelte
@@ -30,46 +30,36 @@
 	import { formatTime } from '$lib/utils/timeUtils';
 
 	import {
-		sections,
-		selectedSectionId,
-		addSection,
-		initializeSections,
-		totalPlanDuration, // Moved here
-		formatDrillItem,
-		initializeTimelinesFromPlan,
-		removeSection,
-		removeItem,
-		handleDurationChange,
-		handleTimelineChange,
-		handleUngroup,
-		getTimelineName,
-		getTimelineColor,
-		customTimelineNames,
-		selectedTimelines,
-		addBreak,
-		addDrillToPlan,
-		addOneOffDrill,
-		addFormationToPlan,
-		addParallelActivities,
-		updateTimelineColor,
-		updateTimelineName,
-		handleTimelineSave
-		// handleDrillMove // Dnd logic likely uses this, ensure it's available if needed
-	} from '$lib/stores/sectionsStore';
+import {
+    sections,
+    initializeSections,
+    initializeTimelinesFromPlan,
+    getTimelineName,
+    getTimelineColor,
+    customTimelineNames,
+    selectedTimelines,
+    addBreak,
+    addDrillToPlan,
+    addOneOffDrill,
+    addFormationToPlan,
+    addParallelActivities,
+    updateTimelineColor,
+    updateTimelineName,
+    handleTimelineSave
+} from "$lib/stores/sectionsStore";
 
 	// Import component modules
 	import EnhancedAddItemModal from '$lib/components/practice-plan/modals/EnhancedAddItemModal.svelte';
 	import TimelineSelectorModal from '$lib/components/practice-plan/modals/TimelineSelectorModal.svelte';
-	import SectionContainer from '$lib/components/practice-plan/sections/SectionContainer.svelte';
-	import PlanMetadataFields from '$lib/components/practice-plan/PlanMetadataFields.svelte';
-	import { Button } from '$lib/components/ui/button'; // Restore the original button import
-	import SimpleButton from './components/SimpleButton.svelte'; // Import the new simple button
-	import Spinner from '$lib/components/Spinner.svelte'; // Assuming Spinner is top-level
-
-	// Import TinyMCE editor
 	let Editor;
 
 	// Add proper prop definitions with defaults
+import PlanMetadataFields from "$lib/components/practice-plan/PlanMetadataFields.svelte";
+import PracticePlanActions from "$lib/components/practice-plan/PracticePlanActions.svelte";
+import PracticePlanSectionsEditor from "$lib/components/practice-plan/PracticePlanSectionsEditor.svelte";
+import { Button } from "$lib/components/ui/button";
+import Spinner from "$lib/components/Spinner.svelte";
+import { practicePlanAuthHandler } from "$lib/utils/actions/practicePlanAuthHandler.js";
 	export let practicePlan = null;
 	export let mode = practicePlan ? 'edit' : 'create';
 	export let skillOptions = [];
@@ -266,25 +256,6 @@
 		};
 	});
 
-	function addSectionAction() {
-		console.log('[PracticePlanForm.svelte] Add Section button clicked');
-		addSection(); // Call the imported addSection function from the store
-	}
-
-	function onRemoveSection(sectionId) {
-		removeSection(sectionId);
-	}
-
-	function onRemoveItem(sectionIndex, itemIndex) {
-		removeItem(sectionIndex, itemIndex);
-	}
-
-	function onDurationChange(sectionIndex, itemIndex, newDuration) {
-		handleDurationChange(sectionIndex, itemIndex, newDuration);
-	}
-
-	function onUngroup(groupId) {
-		handleUngroup(groupId);
 	}
 	
 	// Modal event handlers
@@ -309,6 +280,7 @@
 
 <!-- Wrap form in <form> tag and apply enhance -->
 <form
+        use:practicePlanAuthHandler
 	method="POST"
 	action="?"
 	use:enhance={({ formElement, formData, action, cancel, submitter }) => {
@@ -400,95 +372,18 @@
 	</h1>
 
 	<!-- Duration Summary -->
-	<div class="bg-blue-50 p-4 rounded-lg shadow-sm flex justify-between items-center">
-		<div>
-			<h2 class="font-semibold text-blue-800">Practice Duration</h2>
-			<p class="text-blue-600">
-				Start: {formatTime($startTime)} • Total: {$totalPlanDuration} minutes
-			</p>
-			<p class="text-xs text-blue-500 mt-1">
-				Keyboard shortcuts: Ctrl+Z (Undo), Ctrl+Shift+Z (Redo)
-			</p>
-		</div>
-		<div class="flex items-center gap-4">
-			<Button variant="outline" size="icon" on:click={undo} disabled={!$canUndo} title="Undo">
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke-width="1.5"
-					stroke="currentColor"
-					class="w-5 h-5"
-					><path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"
-					/></svg
-				>
-			</Button>
-			<Button variant="outline" size="icon" on:click={redo} disabled={!$canRedo} title="Redo">
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke-width="1.5"
-					stroke="currentColor"
-					class="w-5 h-5"
-					><path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						d="m15 15 6-6m0 0-6-6m6 6H9a6 6 0 0 0 0 12h3"
-					/></svg
-				>
-			</Button>
-			<div class="text-3xl font-bold text-blue-700">{$totalPlanDuration}m</div>
-		</div>
-	</div>
+        <PracticePlanActions />
 
 	<!-- Metadata Fields -->
 	<PlanMetadataFields {skillOptions} {focusAreaOptions} />
 
-	<!-- Practice Plan Sections -->
-	<div class="practice-plan-sections space-y-4">
-		<h2 class="text-xl font-semibold">Plan Sections & Items</h2>
-		{#each $sections as section, sectionIndex}
-			<SectionContainer
-				{section}
-				{sectionIndex}
-				on:openDrillSearch={handleOpenDrillSearch}
-				on:openTimelineSelector={handleOpenTimelineSelector}
-				{onRemoveSection}
-				{onRemoveItem}
-				{onDurationChange}
-				onTimelineChange={handleTimelineChange}
-				{onUngroup}
-				timelineNameGetter={getTimelineName}
-				customTimelineNamesData={$customTimelineNames}
-			/>
-		{/each}
-
-		<div class="flex gap-2 mt-4">
-			{#if true}
-				{#if false}
-					// Keep native button commented out for now /* <button
-						type="button"
-						class="flex-1 p-2 border rounded"
-						on:click={() =>
-							console.log('[PracticePlanForm.svelte] Native Add Section button clicked!')}
-					>
-						+ Add Section (Native HTML Test)
-					</button> */
-				{/if}
-			{/if}
-		</div>
-	</div>
+        <PracticePlanSectionsEditor
+            on:openDrillSearch={handleOpenDrillSearch}
+            on:openTimelineSelector={handleOpenTimelineSelector}
+        />
 
 	<!-- Visibility controls are handled within PlanMetadataFields -->
 
-	<div class="my-4">
-		<!-- Wrapper for the moved button -->
-		<SimpleButton on:click={addSectionAction} class="flex-1">+ Add Section</SimpleButton>
-	</div>
 
 	<!-- Submit button -->
 	<div class="flex justify-end mt-8">

--- a/tickets/18-refactor-practiceplanform.md
+++ b/tickets/18-refactor-practiceplanform.md
@@ -2,7 +2,7 @@
 
 **Priority:** Medium
 
-**Description:** The [`src/routes/practice-plans/PracticePlanForm.svelte`](src/routes/practice-plans/PracticePlanForm.svelte) component is very large and complex. It manages the entire UI for creating/editing practice plans, integrates multiple stores (`practicePlanStore`, `sectionsStore`, `historyStore`, `cartStore`), handles a fragile authentication flow using `sessionStorage`, loads TinyMCE, manages modals, and contains complex initialization logic.
+**Description:** The [`src/routes/practice-plans/PracticePlanForm.svelte`](src/routes/practice-plans/PracticePlanForm.svelte) component remains quite large. It coordinates creation/editing of practice plans, integrates several stores (`practicePlanMetadataStore`, `sectionsStore`, `historyStore`, `cartStore`), loads TinyMCE, manages modals and undo/redo, and contains initialization logic for pulling drills from the cart when creating a new plan. The old `practicePlanStore` has been removed and basic metadata fields were moved to `PlanMetadataFields.svelte`. Authentication during save now uses a cookie-based "pending plan" flow handled by `/api/pending-plans` instead of `sessionStorage`.
 
 **Affected Files:**
 
@@ -16,18 +16,13 @@
 
 **Action Required:**
 
-1.  **Break Down Component:** Decompose the form into smaller, more manageable sub-components. Potential candidates:
-    - `PracticePlanMetadataForm`: Handles basic fields (name, description, goals, visibility, etc.).
+1.  **Break Down Component:** Decompose the form into smaller, more manageable sub-components. `PlanMetadataFields.svelte` already encapsulates the metadata inputs, but additional pieces could be extracted:
     - `PracticePlanSectionsEditor`: Handles the rendering and high-level interaction with the sections/items list (using [`SectionContainer`](src/components/practice-plan/sections/SectionContainer.svelte) etc.).
-    - `PracticePlanActions`: Handles buttons like Save, Cancel, Undo/Redo.
-    - `PracticePlanAuthHandler`: Encapsulates the logic for handling anonymous user saving and post-login association (though ideally replaced by server-side patterns).
-2.  **Simplify State Management:** This component will benefit significantly from the refactoring of `practicePlanStore` (Ticket 09) and `sectionsStore` (Ticket 10), and decoupling of shared components (Ticket 15).
-    - The refactored component should primarily coordinate the sub-components, passing data down and handling events up.
-    - It should interact with the refactored, focused stores (`practicePlanMetadataStore`, `sectionsStore`).
-3.  **Replace Fragile Auth Flow:** The `sessionStorage`-based flow for handling saves across login redirects is unreliable. Replace it with a more robust approach:
-    - **Prefer Server-Side Handling:** Use SvelteKit Form Actions. The form submission should go to a server action. If the user isn't logged in, the action can redirect to login, potentially passing a redirect URL back to the form page. SvelteKit's form enhancement can preserve form data across redirects more reliably than manual `sessionStorage` use (needs verification for OAuth flows).
-    - **Alternative Client-Side:** If client-side handling is strictly necessary, ensure error handling for `sessionStorage` issues and consider alternative temporary storage if needed.
-4.  **Improve Initialization Logic:** Simplify the `onMount` logic. With Form Actions, much of the state restoration might become unnecessary. Initialization should clearly handle create vs. edit scenarios based on data passed from the `load` function.
-5.  **Centralize Submission:** Use SvelteKit Form Actions for submission logic (as per Ticket 09 refactoring). This moves API calls, validation, normalization, and feedback handling to the server-side action associated with the form.
-6.  **Clarify Validation:** Integrate with the centralized validation system (Ticket 14). Use form actions to report validation errors back to the form UI.
+    - `PracticePlanActions`: Handles buttons like Save, Cancel, Undo/Redo. The `SimpleButton` workaround for adding sections lives in `src/routes/practice-plans/components/SimpleButton.svelte`.
+    - `PracticePlanAuthHandler`: Encapsulates the logic for handling anonymous user saving and post-login association (now via the `/api/pending-plans` flow).
+2.  **Simplify State Management:** `practicePlanStore` has been removed. The form now uses `practicePlanMetadataStore` for basic fields and `sectionsStore` for plan structure. Further cleanup is still needed so the component merely coordinates sub-components and delegates mutations to these stores.
+3.  **Replace Fragile Auth Flow:** The previous `sessionStorage` approach has been dropped. Saving a plan while unauthenticated now posts the data to `/api/pending-plans`, sets a `pendingPlanToken` cookie, and redirects to login. After login, `/practice-plans/[id]/edit/+page.server.js` loads the pending plan via that cookie. Verify this flow works across OAuth redirects and consider persisting pending plans in a durable store if needed.
+4.  **Improve Initialization Logic:** Some initialization has been simplified; the form now initializes from a passed in `practicePlan` object and pulls drills from `cartStore` when creating a new plan. Remaining logic around history setup and cart population could be encapsulated in helper functions.
+5.  **Centralize Submission:** Implemented. Both `create/+page.server.js` and `[id]/edit/+page.server.js` now contain form actions that validate with Zod, normalize sections and redirect on success.
+6.  **Clarify Validation:** Metadata fields validate via `practicePlanMetadataStore.validateMetadataForm` and server actions use the shared `practicePlanSchema`. Errors are exposed on `$page.form` and displayed next to inputs, but review is needed to ensure all sections/items constraints surface correctly to the user.
 7.  **Review Modal Interactions:** Ensure interactions with modals ([`EmptyCartModal`](src/components/practice-plan/modals/EmptyCartModal.svelte), [`DrillSearchModal`](src/components/practice-plan/modals/DrillSearchModal.svelte), [`TimelineSelectorModal`](src/components/practice-plan/modals/TimelineSelectorModal.svelte)) follow the decoupled pattern (dispatching events, handling events) proposed in Ticket 15.


### PR DESCRIPTION
## Summary
- modularize practice plan form into smaller components
- add auth handler action for unauthenticated plan saves
- wire new components into `PracticePlanForm`

## Testing
- `pnpm test` *(fails: Database errors in unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_687a8d9b19308325ad11c9f53470bb87