### PR TITLE
Complete Excalidraw diagram integration

### DIFF
--- a/src/lib/components/ExcalidrawModal.svelte
+++ b/src/lib/components/ExcalidrawModal.svelte
@@ -1,0 +1,124 @@
+<script>
+	import { createEventDispatcher, onMount, tick } from 'svelte';
+	import { createExcalidrawComponent } from '$lib/utils/createExcalidrawComponent.js';
+
+	export let initialData;
+	export let readonly = false;
+
+	const dispatch = createEventDispatcher();
+	let excalidrawAPI;
+	let ExcalidrawComponent;
+	let container;
+
+	function handleSave() {
+		if (!excalidrawAPI) return;
+		const elements = excalidrawAPI.getSceneElements();
+		const appState = excalidrawAPI.getAppState();
+		const files = excalidrawAPI.getFiles();
+		dispatch('save', { elements, appState, files });
+	}
+
+	function handleCancel() {
+		dispatch('cancel');
+	}
+
+	onMount(async () => {
+		ExcalidrawComponent = await createExcalidrawComponent({
+			excalidrawAPI: (api) => (excalidrawAPI = api),
+			initialData,
+			viewModeEnabled: readonly,
+			onChange: () => {},
+			gridModeEnabled: false,
+			theme: 'light',
+			name: 'fullscreen',
+			UIOptions: {
+				canvasActions: { export: false, loadScene: false, saveAsImage: false, theme: false }
+			}
+		});
+		await tick();
+	});
+</script>
+
+<div class="modal-overlay">
+	<div class="modal-content">
+		<div class="modal-header">
+			<h2 class="text-xl font-bold">Edit Diagram</h2>
+			<div class="flex gap-2">
+				<button
+					class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+					on:click={handleSave}
+				>
+					Save &amp; Close
+				</button>
+				<button
+					class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700"
+					on:click={handleCancel}
+				>
+					Cancel
+				</button>
+			</div>
+		</div>
+		<div class="editor-container" bind:this={container}>
+			{#if ExcalidrawComponent}
+				<div class="excalidraw-fullscreen-wrapper" use:ExcalidrawComponent.render></div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.modal-overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: rgba(0, 0, 0, 0.75);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 9999;
+	}
+
+	.modal-content {
+		width: 95vw;
+		height: 95vh;
+		background: white;
+		display: flex;
+		flex-direction: column;
+		border-radius: 0.5rem;
+		overflow: hidden;
+	}
+
+	.modal-header {
+		padding: 1rem;
+		background-color: white;
+		border-bottom: 1px solid #e5e7eb;
+		z-index: 1;
+	}
+
+	.editor-container {
+		flex: 1;
+		position: relative;
+		overflow: hidden;
+	}
+
+	.excalidraw-fullscreen-wrapper {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		overflow: hidden;
+	}
+
+	:global(.excalidraw-fullscreen-wrapper .excalidraw) {
+		width: 100% !important;
+		height: 100% !important;
+	}
+
+	:global(.excalidraw-fullscreen-wrapper .excalidraw-container) {
+		width: 100% !important;
+		height: 100% !important;
+	}
+</style>

--- a/src/lib/components/ExcalidrawRenderer.svelte
+++ b/src/lib/components/ExcalidrawRenderer.svelte
@@ -6,4 +6,4 @@
 	export let sceneData;
 </script>
 
-<ExcalidrawWrapper data={sceneData} readonly={true} showSaveButton={false} />
+<ExcalidrawWrapper data={sceneData} id="renderer" readonly={true} />

--- a/src/lib/components/ExcalidrawWrapper.svelte
+++ b/src/lib/components/ExcalidrawWrapper.svelte
@@ -1,6 +1,8 @@
 <script>
 	import { onMount, createEventDispatcher, tick } from 'svelte';
 	import { browser } from '$app/environment';
+	import ExcalidrawModal from '$lib/components/ExcalidrawModal.svelte';
+	import { createExcalidrawComponent } from '$lib/utils/createExcalidrawComponent.js';
 	import {
 		createInitialImageElements,
 		CANVAS_WIDTH,
@@ -9,32 +11,18 @@
 
 	export let data = null;
 	export let id = '';
-	export let showSaveButton = false;
-	export let index;
 	export let readonly = false;
 	export let template = 'blank';
 	export let startFullscreen = false;
 
 	const dispatch = createEventDispatcher();
 	let excalidrawAPI;
-	let fullscreenExcalidrawAPI;
 	let ExcalidrawComponent;
 	let isFullscreen = startFullscreen;
 	let initialSceneData = null;
+	let fullscreenData = null;
 	let excalidrawWrapper;
 	let hasInitialized = false;
-
-	let fullscreenExcalidrawComponent;
-	let fullscreenContainer;
-
-	function openEditor() {
-		showModal = true;
-	}
-
-	function closeEditor() {
-		showModal = false;
-	}
-
 	if (browser) {
 		window.process = {
 			env: {
@@ -43,183 +31,28 @@
 		};
 	}
 
-	function zoomToIncludeAllElements(api) {
-		if (!api) return;
-
-		const elements = api.getSceneElements();
-		if (!elements.length) return;
-
-		// Find the bounds of all elements
-		let minX = Infinity;
-		let minY = Infinity;
-		let maxX = -Infinity;
-		let maxY = -Infinity;
-
-		elements.forEach((el) => {
-			// For lines, we need to consider their points
-			if (el.type === 'line' && el.points) {
-				el.points.forEach((point) => {
-					const absoluteX = el.x + point[0];
-					const absoluteY = el.y + point[1];
-					minX = Math.min(minX, absoluteX);
-					minY = Math.min(minY, absoluteY);
-					maxX = Math.max(maxX, absoluteX);
-					maxY = Math.max(maxY, absoluteY);
-				});
-			} else {
-				// For other elements
-				const left = el.x;
-				const top = el.y;
-				const right = el.x + (el.width || 0);
-				const bottom = el.y + (el.height || 0);
-
-				minX = Math.min(minX, left);
-				minY = Math.min(minY, top);
-				maxX = Math.max(maxX, right);
-				maxY = Math.max(maxY, bottom);
-			}
-		});
-
-		// Add padding (40% for more space)
-		const padding = 0.4;
-		const width = maxX - minX;
-		const height = maxY - minY;
-		minX -= width * padding;
-		minY -= height * padding;
-		maxX += width * padding;
-		maxY += height * padding;
-
-		// Calculate center point
-		const centerX = (minX + maxX) / 2;
-		const centerY = (minY + maxY) / 2;
-
-		// Calculate zoom level
-		const containerWidth = fullscreenContainer?.offsetWidth || window.innerWidth;
-		const containerHeight = fullscreenContainer?.offsetHeight || window.innerHeight;
-
-		const zoomX = containerWidth / (maxX - minX);
-		const zoomY = containerHeight / (maxY - minY);
-		const zoom = Math.min(zoomX, zoomY, 0.7); // Cap at 0.7 to ensure some padding
-
-		// Update the view
-		api.updateScene({
-			appState: {
-				...api.getAppState(),
-				scrollX: containerWidth / 2 - centerX * zoom,
-				scrollY: containerHeight / 2 - centerY * zoom,
-				zoom: {
-					value: zoom
-				}
-			}
-		});
-	}
-
 	function toggleFullscreen() {
 		if (!excalidrawAPI) return;
-		isFullscreen = !isFullscreen;
-
-		if (isFullscreen) {
-			try {
-				tick().then(() => {
-					if (fullscreenExcalidrawAPI) {
-						const currentState = {
-							elements: excalidrawAPI.getSceneElements() || [],
-							appState: excalidrawAPI.getAppState() || {},
-							files: excalidrawAPI.getFiles() || {}
-						};
-
-						fullscreenExcalidrawAPI.updateScene(currentState);
-						setTimeout(() => zoomToIncludeAllElements(fullscreenExcalidrawAPI), 100);
-					}
-				});
-			} catch (error) {
-				console.error('Error initializing fullscreen mode:', error);
-				isFullscreen = false;
-			}
-		}
+		fullscreenData = {
+			elements: excalidrawAPI.getSceneElements() || [],
+			appState: excalidrawAPI.getAppState() || {},
+			files: excalidrawAPI.getFiles() || {}
+		};
+		isFullscreen = true;
 	}
 
-	async function createFullscreenComponent() {
-		try {
-			const React = await import('react');
-			const ReactDOM = await import('react-dom/client');
-			const { Excalidraw } = await import('@excalidraw/excalidraw');
-
-			const excalidrawProps = {
-				onReady: (api) => {
-					fullscreenExcalidrawAPI = api;
-					if (initialSceneData) {
-						api.updateScene(initialSceneData);
-					}
-				},
-				initialData: initialSceneData,
-				viewModeEnabled: readonly,
-				onChange: handleChange,
-				gridModeEnabled: false,
-				theme: 'light',
-				name: `${id}-fullscreen`,
-				UIOptions: {
-					canvasActions: {
-						export: false,
-						loadScene: false,
-						saveAsImage: false,
-						theme: false
-					}
-				}
-			};
-
-			fullscreenExcalidrawComponent = {
-				render: (node) => {
-					const root = ReactDOM.createRoot(node);
-					root.render(
-						React.createElement(Excalidraw, { ...excalidrawProps, portalContainer: node })
-					);
-					return {
-						destroy: () => root.unmount()
-					};
-				}
-			};
-		} catch (error) {
-			console.error('Error creating fullscreen component:', error);
-			isFullscreen = false;
-		}
-	}
-
-	function handleSaveAndClose() {
-		if (!fullscreenExcalidrawAPI) return;
-
-		try {
-			const elements = fullscreenExcalidrawAPI.getSceneElements();
-			const appState = fullscreenExcalidrawAPI.getAppState();
-			const files = fullscreenExcalidrawAPI.getFiles();
-
-			// Update initialData to match current state
-			initialSceneData = {
-				elements,
-				appState: { ...appState, viewBackgroundColor: appState.viewBackgroundColor },
-				files
-			};
-
-			isFullscreen = false;
-
-			tick().then(() => {
-				if (excalidrawAPI) {
-					// Update the preview with latest state
-					excalidrawAPI.updateScene(initialSceneData);
-					dispatch('save', initialSceneData);
-				}
-			});
-		} catch (error) {
-			console.error('Error in handleSaveAndClose:', error);
-			isFullscreen = false;
-		}
-	}
-
-	function handleCancel() {
+	function handleModalSave(event) {
+		initialSceneData = event.detail;
 		isFullscreen = false;
-		// No need to restore state since we'll get fresh state next time
+		if (excalidrawAPI) {
+			excalidrawAPI.updateScene(initialSceneData);
+		}
+		dispatch('save', initialSceneData);
 	}
 
+	function handleModalCancel() {
+		isFullscreen = false;
+	}
 	function handleChange(elements, appState, files) {
 		if (!readonly) {
 			const sceneData = {
@@ -297,36 +130,12 @@
 		return elements;
 	}
 
-	function handleImageElements(elements, files) {
-		elements.forEach((element) => {
-			if (element.type === 'image') {
-				const file = files[element.fileId];
-				if (file?.staticPath) {
-					element.staticImagePath = file.staticPath;
-				} else if (file?.dataURL) {
-					element.dataURL = file.dataURL;
-				} else {
-					console.warn('Image element missing both staticPath and dataURL:', {
-						elementId: element.fileId,
-						element: element
-					});
-				}
-			}
-		});
-		return elements;
-	}
-
 	onMount(async () => {
 		if (!browser) return;
 		if (hasInitialized) return;
 
 		hasInitialized = true;
 		try {
-			const React = await import('react');
-			const ReactDOM = await import('react-dom/client');
-			window.React = React.default;
-			const { Excalidraw } = await import('@excalidraw/excalidraw');
-
 			// If there's no data or empty data, create from scratch; else fix and load existing data
 			if (!data || (data.elements && data.elements.length === 0)) {
 				initialSceneData = await createInitialImageElements(template);
@@ -337,7 +146,6 @@
 					appState: {
 						viewBackgroundColor: '#ffffff',
 						gridSize: 20,
-						collaborators: [],
 						...(data.appState || {}),
 						// Ensure we have a collaborators array
 						collaborators: Array.isArray(data.appState?.collaborators)
@@ -347,17 +155,11 @@
 					files: data.files || {}
 				};
 			}
-
-			// Use initialSceneData in both places:
-			const createExcalidrawProps = (isFullscreenVersion = false) => ({
+			ExcalidrawComponent = await createExcalidrawComponent({
 				excalidrawAPI: (api) => {
-					if (isFullscreenVersion) {
-						fullscreenExcalidrawAPI = api;
-					} else {
-						excalidrawAPI = api;
-						if (!isFullscreen) {
-							setTimeout(() => centerAndZoomToGuideRectangle(api), 100);
-						}
+					excalidrawAPI = api;
+					if (!isFullscreen) {
+						setTimeout(() => centerAndZoomToGuideRectangle(api), 100);
 					}
 				},
 				initialData: initialSceneData,
@@ -365,39 +167,11 @@
 				onChange: handleChange,
 				gridModeEnabled: false,
 				theme: 'light',
-				name: isFullscreenVersion ? `${id}-fullscreen` : id,
+				name: id,
 				UIOptions: {
-					canvasActions: {
-						export: false,
-						loadScene: false,
-						saveAsImage: false,
-						theme: false
-					}
+					canvasActions: { export: false, loadScene: false, saveAsImage: false, theme: false }
 				}
 			});
-
-			// Mount the normal Excalidraw component
-			ExcalidrawComponent = {
-				render: (node) => {
-					const root = ReactDOM.createRoot(node);
-					root.render(React.createElement(Excalidraw, createExcalidrawProps(false)));
-					return {
-						destroy: () => root.unmount()
-					};
-				}
-			};
-
-			// Mount the fullscreen Excalidraw component
-			fullscreenExcalidrawComponent = {
-				render: (node) => {
-					const root = ReactDOM.createRoot(node);
-					root.render(React.createElement(Excalidraw, createExcalidrawProps(true)));
-					return {
-						destroy: () => root.unmount()
-					};
-				}
-			};
-
 			await tick();
 		} catch (error) {
 			console.error('Error mounting Excalidraw:', error);
@@ -466,38 +240,13 @@
 			</div>
 		</div>
 	{/if}
-
-	<!-- Fullscreen Modal -->
 	{#if isFullscreen}
-		<div class="modal-overlay">
-			<div class="modal-content">
-				<div class="modal-header">
-					<h2 class="text-xl font-bold">Edit Diagram</h2>
-					<div class="flex gap-2">
-						<button
-							class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-							on:click={handleSaveAndClose}
-						>
-							Save & Close
-						</button>
-						<button
-							class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700"
-							on:click={handleCancel}
-						>
-							Cancel
-						</button>
-					</div>
-				</div>
-				<div class="editor-container" bind:this={fullscreenContainer}>
-					{#if fullscreenExcalidrawComponent}
-						<div
-							class="excalidraw-fullscreen-wrapper"
-							use:fullscreenExcalidrawComponent.render
-						></div>
-					{/if}
-				</div>
-			</div>
-		</div>
+		<ExcalidrawModal
+			{readonly}
+			initialData={fullscreenData}
+			on:save={handleModalSave}
+			on:cancel={handleModalCancel}
+		/>
 	{/if}
 </div>
 
@@ -519,64 +268,6 @@
 		position: absolute !important;
 	}
 
-	/* Fix for fullscreen modal */
-	.modal-overlay {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background: rgba(0, 0, 0, 0.75);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		z-index: 9999;
-	}
-
-	.modal-content {
-		width: 95vw;
-		height: 95vh;
-		background: white;
-		display: flex;
-		flex-direction: column;
-		border-radius: 0.5rem;
-		overflow: hidden;
-	}
-
-	.modal-header {
-		padding: 1rem;
-		background-color: white;
-		border-bottom: 1px solid #e5e7eb;
-		z-index: 1;
-	}
-
-	.editor-container {
-		flex: 1;
-		position: relative;
-		overflow: hidden;
-	}
-
-	.excalidraw-fullscreen-wrapper {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		overflow: hidden;
-	}
-
-	/* Update Excalidraw specific styles */
-	:global(.excalidraw-fullscreen-wrapper .excalidraw) {
-		width: 100% !important;
-		height: 100% !important;
-	}
-
-	:global(.excalidraw-fullscreen-wrapper .excalidraw-container) {
-		width: 100% !important;
-		height: 100% !important;
-	}
-
-	/* Add specific mount point styling */
 	:global(.excalidraw-mount-point) {
 		position: absolute !important;
 		top: 0;

--- a/src/lib/utils/createExcalidrawComponent.js
+++ b/src/lib/utils/createExcalidrawComponent.js
@@ -1,0 +1,15 @@
+export async function createExcalidrawComponent(props) {
+	const React = await import('react');
+	const ReactDOM = await import('react-dom/client');
+	const { Excalidraw } = await import('@excalidraw/excalidraw');
+
+	return {
+		render: (node) => {
+			const root = ReactDOM.createRoot(node);
+			root.render(React.createElement(Excalidraw, { ...props, portalContainer: node }));
+			return {
+				destroy: () => root.unmount()
+			};
+		}
+	};
+}

--- a/src/routes/drills/DrillForm.svelte
+++ b/src/routes/drills/DrillForm.svelte
@@ -109,6 +109,10 @@
 
 	let diagramRefs = [];
 
+	$: if ($diagrams) {
+		diagramRefs = new Array($diagrams.length);
+	}
+
 	const drillTypeOptions = [
 		'Competitive',
 		'Skill-focus',
@@ -166,12 +170,15 @@
 		const processedData = {
 			elements: diagramData.elements || [],
 			appState: {
+				viewBackgroundColor: '#ffffff',
+				gridSize: 20,
 				...(diagramData.appState || {}),
 				collaborators: Array.isArray(diagramData.appState?.collaborators)
 					? diagramData.appState.collaborators
 					: []
 			},
-			files: diagramData.files || {}
+			files: diagramData.files || {},
+			template: $diagrams[index]?.template || 'blank'
 		};
 		diagrams.update((d) => {
 			const newDiagrams = [...d];
@@ -571,7 +578,8 @@
 						groupIds: element.groupIds?.map(() => crypto.randomUUID())
 					})) || [],
 				appState: { ...diagramToDuplicate.appState },
-				files: { ...diagramToDuplicate.files }
+				files: { ...diagramToDuplicate.files },
+				template: diagramToDuplicate.template
 			};
 
 			const newDiagrams = [...d];
@@ -950,6 +958,137 @@
 							/>
 						</div>
 
+						<!-- Diagrams Section -->
+						<div class="mb-6">
+							<label class="block text-gray-700 font-medium mb-2" for="diagrams">
+								Diagrams
+								<span class="text-sm text-gray-500 font-normal"
+									>(Optional - Add visual diagrams to illustrate your drill)</span
+								>
+							</label>
+
+							<!-- Existing Diagrams -->
+							{#if $diagrams && $diagrams.length > 0}
+								<div class="space-y-4 mb-4">
+									{#each $diagrams as diagram, diagramIndex (diagramIndex)}
+										<div
+											class="border border-gray-300 rounded-lg bg-white shadow-sm overflow-hidden"
+										>
+											<div class="bg-gray-50 px-4 py-3 border-b border-gray-200">
+												<div class="flex justify-between items-center">
+													<h4 class="text-lg font-medium text-gray-700">
+														Diagram {diagramIndex + 1}
+														{#if diagram.template && diagram.template !== 'blank'}
+															<span class="text-sm text-gray-500 ml-2">
+																({diagram.template.replace(/([A-Z])/g, ' $1').trim()})
+															</span>
+														{/if}
+													</h4>
+
+													<div class="flex items-center gap-2">
+														<div class="flex gap-1 mr-2">
+															<button
+																type="button"
+																on:click={() => handleMoveUp(diagramIndex)}
+																disabled={diagramIndex === 0}
+																class="p-1 text-gray-600 hover:text-gray-800 disabled:text-gray-400 disabled:cursor-not-allowed"
+																title="Move up"
+															>
+																<svg
+																	class="w-5 h-5"
+																	fill="none"
+																	stroke="currentColor"
+																	viewBox="0 0 24 24"
+																>
+																	<path
+																		stroke-linecap="round"
+																		stroke-linejoin="round"
+																		stroke-width="2"
+																		d="M5 15l7-7 7 7"
+																	></path>
+																</svg>
+															</button>
+															<button
+																type="button"
+																on:click={() => handleMoveDown(diagramIndex)}
+																disabled={diagramIndex === $diagrams.length - 1}
+																class="p-1 text-gray-600 hover:text-gray-800 disabled:text-gray-400 disabled:cursor-not-allowed"
+																title="Move down"
+															>
+																<svg
+																	class="w-5 h-5"
+																	fill="none"
+																	stroke="currentColor"
+																	viewBox="0 0 24 24"
+																>
+																	<path
+																		stroke-linecap="round"
+																		stroke-linejoin="round"
+																		stroke-width="2"
+																		d="M19 9l-7 7-7-7"
+																	></path>
+																</svg>
+															</button>
+														</div>
+
+														<button
+															type="button"
+															on:click={() => duplicateDiagram(diagramIndex)}
+															class="px-3 py-1 text-sm bg-blue-100 text-blue-700 hover:bg-blue-200 rounded-md transition-colors"
+														>
+															Duplicate
+														</button>
+														<button
+															type="button"
+															on:click={() => deleteDiagram(diagramIndex)}
+															class="px-3 py-1 text-sm bg-red-100 text-red-700 hover:bg-red-200 rounded-md transition-colors"
+														>
+															Delete
+														</button>
+													</div>
+												</div>
+											</div>
+
+											<div class="p-4">
+												<div class="excalidraw-form-container" style="height: 500px;">
+													<ExcalidrawWrapper
+														data={diagram}
+														id={`drill-${drill.id || 'new'}-diagram-${diagramIndex}`}
+														readonly={false}
+														template={diagram.template || 'blank'}
+														startFullscreen={false}
+														on:save={(event) => handleDiagramSave(event, diagramIndex)}
+														bind:this={diagramRefs[diagramIndex]}
+													/>
+												</div>
+											</div>
+										</div>
+									{/each}
+								</div>
+							{/if}
+
+							<button
+								type="button"
+								on:click={() => (showAddDiagramModal = true)}
+								class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+							>
+								<svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M12 4v16m8-8H4"
+									></path>
+								</svg>
+								Add Diagram
+							</button>
+
+							<p class="mt-2 text-sm text-gray-500">
+								Use diagrams to show field setup, player positions, movement patterns, or drill
+								progressions.
+							</p>
+						</div>
+
 						<div class="flex flex-col">
 							<label for="visibility-select" class="mb-1 text-sm font-medium text-gray-700"
 								>Visibility:</label
@@ -1156,5 +1295,16 @@
 		top: 1rem;
 		right: 1rem;
 		z-index: 9999;
+	}
+
+	.excalidraw-form-container {
+		border: 1px solid #e5e7eb;
+		border-radius: 0.375rem;
+		overflow: hidden;
+		position: relative;
+	}
+
+	.excalidraw-form-container :global(.excalidraw) {
+		background: #ffffff;
 	}
 </style>

--- a/src/routes/drills/[id]/+page.svelte
+++ b/src/routes/drills/[id]/+page.svelte
@@ -495,8 +495,7 @@
 									<ExcalidrawWrapper
 										data={diagramData}
 										id={`diagram-${$drill.id}-${index}`}
-										{index}
-										viewOnly={true}
+										readonly={true}
 									/>
 								</div>
 							{/each}

--- a/src/routes/drills/bulk-upload/+page.svelte
+++ b/src/routes/drills/bulk-upload/+page.svelte
@@ -672,9 +672,8 @@ Example Drill,A brief description,A more detailed description,"Competitive,Skill
 								{#each drill.diagrams as diagram, diagIndex (diagIndex)}
 									<ExcalidrawWrapper
 										data={diagram}
-										{index}
-										{diagIndex}
-										showSaveButton={drill.editableDiagramIndex === diagIndex}
+										id={`bulk-drill-${index}-diagram-${diagIndex}`}
+										readonly={drill.editableDiagramIndex !== diagIndex}
 										on:save={(event) => saveDiagram(index, diagIndex, event)}
 									/>
 									{#if drill.editableDiagramIndex === diagIndex}
@@ -777,9 +776,8 @@ Example Drill,A brief description,A more detailed description,"Competitive,Skill
 								{#each drill.diagrams as diagram, diagIndex (diagIndex)}
 									<ExcalidrawWrapper
 										data={diagram}
-										{index}
-										{diagIndex}
-										showSaveButton={drill.editableDiagramIndex === diagIndex}
+										id={`bulk-drill-${index}-diagram-${diagIndex}`}
+										readonly={drill.editableDiagramIndex !== diagIndex}
 										on:save={(event) => saveDiagram(index, diagIndex, event)}
 									/>
 									{#if drill.editableDiagramIndex === diagIndex}

--- a/src/routes/formations/FormationForm.svelte
+++ b/src/routes/formations/FormationForm.svelte
@@ -741,7 +741,6 @@
 									<ExcalidrawWrapper
 										data={diagram}
 										id={`diagram-${i}`}
-										index={i}
 										bind:this={diagramRefs[i]}
 										on:save={(event) => handleDiagramSave(event, i)}
 									/>

--- a/src/routes/formations/[id]/+page.svelte
+++ b/src/routes/formations/[id]/+page.svelte
@@ -105,7 +105,7 @@
 		</div>
 
 		<!-- Edit/Delete Buttons (Permission check remains) -->
-		{#if formation && $page.data.session && ((dev || $page.data.session.user.id === formation.created_by) || formation.is_editable_by_others)}
+		{#if formation && $page.data.session && (dev || $page.data.session.user.id === formation.created_by || formation.is_editable_by_others)}
 			<div class="flex space-x-4">
 				<button
 					class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
@@ -189,8 +189,6 @@
 											data={diagram}
 											id={`view-diagram-${formation.id}-${i}`}
 											readonly={true}
-											viewModeEnabled={true}
-											zenModeEnabled={false}
 										/>
 									</div>
 								</div>

--- a/src/routes/practice-plans/viewer/DrillCard.svelte
+++ b/src/routes/practice-plans/viewer/DrillCard.svelte
@@ -73,17 +73,17 @@
 		const hour12 = hour % 12 || 12;
 		return `${hour12}:${minutes} ${ampm}`;
 	}
-	
+
 	// Helper functions for position badges
 	function getPositionColor(position) {
 		const colors = {
 			CHASERS: '#3B82F6', // Blue
 			BEATERS: '#EF4444', // Red
-			SEEKERS: '#10B981'  // Green
+			SEEKERS: '#10B981' // Green
 		};
 		return colors[position] || '#6B7280'; // Gray fallback
 	}
-	
+
 	function formatPositionName(position) {
 		if (!position) return '';
 		return position.charAt(0) + position.slice(1).toLowerCase();
@@ -122,8 +122,8 @@
 
 				<!-- Position Badge (only show when not in parallel group) -->
 				{#if item.parallel_timeline && !isInParallelGroup}
-					<span 
-						class="position-badge" 
+					<span
+						class="position-badge"
 						style="background-color: {getPositionColor(item.parallel_timeline)}"
 					>
 						{formatPositionName(item.parallel_timeline)}
@@ -267,14 +267,14 @@
 						{#if normalizedItem.drill?.diagrams?.[0]}
 							<ExcalidrawWrapper
 								data={normalizedItem.drill.diagrams[0]}
+								id={`preview-${index}`}
 								readonly={true}
-								showSaveButton={false}
 							/>
 						{:else if normalizedItem.diagrams?.[0]}
 							<ExcalidrawWrapper
 								data={normalizedItem.diagrams[0]}
+								id={`preview-${index}-alt`}
 								readonly={true}
-								showSaveButton={false}
 							/>
 						{/if}
 					</div>
@@ -348,7 +348,7 @@
 		gap: 0.5rem;
 		flex-grow: 1;
 	}
-	
+
 	.position-badge {
 		padding: 0.125rem 0.5rem;
 		border-radius: 9999px;

--- a/tests/drill-diagrams.spec.js
+++ b/tests/drill-diagrams.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Drill Diagram Functionality', () => {
+    test('should add and save a diagram', async ({ page }) => {
+        await page.goto('/drills/create');
+        await page.fill('input[name="name"]', 'Test Drill with Diagram');
+        await page.fill('textarea[name="brief_description"]', 'Test description');
+        await page.click('button:has-text("Add Diagram")');
+        await page.selectOption('select#template-select', 'fullCourt');
+        await page.click('button:has-text("Add"):visible');
+        await page.waitForSelector('.excalidraw', { timeout: 10000 });
+        await page.click('button:has-text("Create Drill")');
+        await expect(page).toHaveURL(/\/drills\/\d+/);
+        await expect(page.locator('.excalidraw')).toBeVisible();
+    });
+
+    test('should edit diagram in fullscreen', async ({ page }) => {
+        await page.goto('/drills/151/edit');
+        await page.click('button:has-text("Fullscreen")');
+        await expect(page.locator('.modal-overlay')).toBeVisible();
+        await page.click('button:has-text("Save & Close")');
+        await expect(page.locator('.modal-overlay')).not.toBeVisible();
+    });
+});


### PR DESCRIPTION
## Summary
- add new `ExcalidrawModal` component and util `createExcalidrawComponent`
- refactor `ExcalidrawWrapper` to use fullscreen modal
- render diagrams in `DrillForm` and update save logic
- fix Excalidraw props in bulk upload and drill/formation pages
- add Playwright spec for diagram features

## Testing
- `pnpm run lint` *(fails: 308 errors)*
- `pnpm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c02e3c5748325a2311b0624b856fc