### PR TITLE
Finish Excalidraw wrapper feature

### DIFF
--- a/src/lib/components/ExcalidrawModal.svelte
+++ b/src/lib/components/ExcalidrawModal.svelte
@@ -1,0 +1,124 @@
+<script>
+import { createEventDispatcher, onMount, tick } from 'svelte';
+import { createExcalidrawComponent } from '$lib/utils/createExcalidrawComponent.js';
+
+export let initialData;
+export let readonly = false;
+
+const dispatch = createEventDispatcher();
+let excalidrawAPI;
+let ExcalidrawComponent;
+let container;
+
+function handleSave() {
+if (!excalidrawAPI) return;
+const elements = excalidrawAPI.getSceneElements();
+const appState = excalidrawAPI.getAppState();
+const files = excalidrawAPI.getFiles();
+dispatch('save', { elements, appState, files });
+}
+
+function handleCancel() {
+dispatch('cancel');
+}
+
+onMount(async () => {
+ExcalidrawComponent = await createExcalidrawComponent({
+excalidrawAPI: (api) => (excalidrawAPI = api),
+initialData,
+viewModeEnabled: readonly,
+onChange: () => {},
+gridModeEnabled: false,
+theme: 'light',
+name: 'fullscreen',
+UIOptions: {
+canvasActions: { export: false, loadScene: false, saveAsImage: false, theme: false }
+}
+});
+await tick();
+});
+</script>
+
+<div class="modal-overlay">
+<div class="modal-content">
+<div class="modal-header">
+<h2 class="text-xl font-bold">Edit Diagram</h2>
+<div class="flex gap-2">
+<button
+class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+on:click={handleSave}
+>
+Save &amp; Close
+</button>
+<button
+class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700"
+on:click={handleCancel}
+>
+Cancel
+</button>
+</div>
+</div>
+<div class="editor-container" bind:this={container}>
+{#if ExcalidrawComponent}
+<div class="excalidraw-fullscreen-wrapper" use:ExcalidrawComponent.render></div>
+{/if}
+</div>
+</div>
+</div>
+
+<style>
+.modal-overlay {
+position: fixed;
+top: 0;
+left: 0;
+right: 0;
+bottom: 0;
+background: rgba(0, 0, 0, 0.75);
+display: flex;
+align-items: center;
+justify-content: center;
+z-index: 9999;
+}
+
+.modal-content {
+width: 95vw;
+height: 95vh;
+background: white;
+display: flex;
+flex-direction: column;
+border-radius: 0.5rem;
+overflow: hidden;
+}
+
+.modal-header {
+padding: 1rem;
+background-color: white;
+border-bottom: 1px solid #e5e7eb;
+z-index: 1;
+}
+
+.editor-container {
+flex: 1;
+position: relative;
+overflow: hidden;
+}
+
+.excalidraw-fullscreen-wrapper {
+position: absolute;
+top: 0;
+left: 0;
+right: 0;
+bottom: 0;
+overflow: hidden;
+}
+
+:global(.excalidraw-fullscreen-wrapper .excalidraw) {
+width: 100% !important;
+height: 100% !important;
+}
+
+:global(.excalidraw-fullscreen-wrapper .excalidraw-container) {
+width: 100% !important;
+height: 100% !important;
+}
+</style>

--- a/src/lib/components/ExcalidrawRenderer.svelte
+++ b/src/lib/components/ExcalidrawRenderer.svelte
@@ -1,9 +1,8 @@
 <script>
-	// Thin wrapper to render Excalidraw diagrams in readonly mode for admin/testing pages.
-	import ExcalidrawWrapper from '$lib/components/ExcalidrawWrapper.svelte';
+// Thin wrapper to render Excalidraw diagrams in readonly mode for admin/testing pages.
+import ExcalidrawWrapper from '$lib/components/ExcalidrawWrapper.svelte';
 
-	/** @type {import('$lib/components/ExcalidrawWrapper.svelte').default} */
-	export let sceneData;
+export let sceneData;
 </script>
 
-<ExcalidrawWrapper data={sceneData} readonly={true} showSaveButton={false} />
+<ExcalidrawWrapper data={sceneData} id="renderer-diagram" readonly={true} />

--- a/src/lib/components/ExcalidrawWrapper.svelte
+++ b/src/lib/components/ExcalidrawWrapper.svelte
@@ -1,587 +1,279 @@
 <script>
-	import { onMount, createEventDispatcher, tick } from 'svelte';
-	import { browser } from '$app/environment';
-	import {
-		createInitialImageElements,
-		CANVAS_WIDTH,
-		CANVAS_HEIGHT
-	} from '$lib/utils/excalidrawTemplates.js';
+import { onMount, createEventDispatcher, tick } from 'svelte';
+import { browser } from '$app/environment';
+import ExcalidrawModal from '$lib/components/ExcalidrawModal.svelte';
+import { createExcalidrawComponent } from '$lib/utils/createExcalidrawComponent.js';
+import {
+createInitialImageElements,
+CANVAS_WIDTH,
+CANVAS_HEIGHT
+} from '$lib/utils/excalidrawTemplates.js';
 
-	export let data = null;
-	export let id = '';
-	export let showSaveButton = false;
-	export let index;
-	export let readonly = false;
-	export let template = 'blank';
-	export let startFullscreen = false;
+export let data = null;
+export let id = '';
+export let readonly = false;
+export let template = 'blank';
+export let startFullscreen = false;
 
-	const dispatch = createEventDispatcher();
-	let excalidrawAPI;
-	let fullscreenExcalidrawAPI;
-	let ExcalidrawComponent;
-	let isFullscreen = startFullscreen;
-	let initialSceneData = null;
-	let excalidrawWrapper;
-	let hasInitialized = false;
+const dispatch = createEventDispatcher();
+let excalidrawAPI;
+let ExcalidrawComponent;
+let isFullscreen = startFullscreen;
+let initialSceneData = null;
+let fullscreenData = null;
+let excalidrawWrapper;
+let hasInitialized = false;
+if (browser) {
+window.process = {
+env: {
+NODE_ENV: import.meta.env.MODE
+}
+};
+}
 
-	let fullscreenExcalidrawComponent;
-	let fullscreenContainer;
+function toggleFullscreen() {
+if (!excalidrawAPI) return;
+fullscreenData = {
+elements: excalidrawAPI.getSceneElements() || [],
+appState: excalidrawAPI.getAppState() || {},
+files: excalidrawAPI.getFiles() || {}
+};
+isFullscreen = true;
+}
 
-	function openEditor() {
-		showModal = true;
-	}
+function handleModalSave(event) {
+initialSceneData = event.detail;
+isFullscreen = false;
+if (excalidrawAPI) {
+excalidrawAPI.updateScene(initialSceneData);
+}
+dispatch('save', initialSceneData);
+}
 
-	function closeEditor() {
-		showModal = false;
-	}
+function handleModalCancel() {
+isFullscreen = false;
+}
+function handleChange(elements, appState, files) {
+if (!readonly) {
+const sceneData = {
+elements,
+appState: {
+...appState,
+collaborators: [] // Ensure collaborators exists
+},
+files
+};
+dispatch('save', sceneData);
+}
+}
 
-	if (browser) {
-		window.process = {
-			env: {
-				NODE_ENV: import.meta.env.MODE
-			}
-		};
-	}
+function centerAndZoomToGuideRectangle(api) {
+if (!api) return;
 
-	function zoomToIncludeAllElements(api) {
-		if (!api) return;
+const elements = api.getSceneElements();
+if (!elements.length) return;
 
-		const elements = api.getSceneElements();
-		if (!elements.length) return;
+// Find the guide rectangle
+const guideRect = elements.find(
+(el) => el.type === 'rectangle' && el.strokeColor === '#ff0000' && el.strokeStyle === 'dashed'
+);
 
-		// Find the bounds of all elements
-		let minX = Infinity;
-		let minY = Infinity;
-		let maxX = -Infinity;
-		let maxY = -Infinity;
+if (!guideRect) return;
 
-		elements.forEach((el) => {
-			// For lines, we need to consider their points
-			if (el.type === 'line' && el.points) {
-				el.points.forEach((point) => {
-					const absoluteX = el.x + point[0];
-					const absoluteY = el.y + point[1];
-					minX = Math.min(minX, absoluteX);
-					minY = Math.min(minY, absoluteY);
-					maxX = Math.max(maxX, absoluteX);
-					maxY = Math.max(maxY, absoluteY);
-				});
-			} else {
-				// For other elements
-				const left = el.x;
-				const top = el.y;
-				const right = el.x + (el.width || 0);
-				const bottom = el.y + (el.height || 0);
+// Calculate zoom level as before
+const container = excalidrawWrapper?.querySelector('.excalidraw-container');
+if (!container) return;
 
-				minX = Math.min(minX, left);
-				minY = Math.min(minY, top);
-				maxX = Math.max(maxX, right);
-				maxY = Math.max(maxY, bottom);
-			}
-		});
+const containerWidth = container.offsetWidth;
+const containerHeight = container.offsetHeight;
 
-		// Add padding (40% for more space)
-		const padding = 0.4;
-		const width = maxX - minX;
-		const height = maxY - minY;
-		minX -= width * padding;
-		minY -= height * padding;
-		maxX += width * padding;
-		maxY += height * padding;
+const zoomX = containerWidth / CANVAS_WIDTH;
+const zoomY = containerHeight / CANVAS_HEIGHT;
+const zoom = Math.min(zoomX, zoomY, 1);
 
-		// Calculate center point
-		const centerX = (minX + maxX) / 2;
-		const centerY = (minY + maxY) / 2;
+// Set scroll position to align with guide rectangle
+// Note: We use 0 for both X and Y to align with top-left
+api.updateScene({
+appState: {
+...api.getAppState(),
+scrollX: 0,
+scrollY: 0,
+zoom: {
+value: zoom
+}
+}
+});
+}
 
-		// Calculate zoom level
-		const containerWidth = fullscreenContainer?.offsetWidth || window.innerWidth;
-		const containerHeight = fullscreenContainer?.offsetHeight || window.innerHeight;
+function fixGuideRectanglePosition(elements) {
+const guideRect = elements.find(
+(el) => el.type === 'rectangle' && el.strokeColor === '#ff0000' && el.strokeStyle === 'dashed'
+);
 
-		const zoomX = containerWidth / (maxX - minX);
-		const zoomY = containerHeight / (maxY - minY);
-		const zoom = Math.min(zoomX, zoomY, 0.7); // Cap at 0.7 to ensure some padding
+if (guideRect && (guideRect.x !== 0 || guideRect.y !== 0)) {
+// Calculate the offset that needs to be applied to all elements
+const offsetX = -guideRect.x;
+const offsetY = -guideRect.y;
 
-		// Update the view
-		api.updateScene({
-			appState: {
-				...api.getAppState(),
-				scrollX: containerWidth / 2 - centerX * zoom,
-				scrollY: containerHeight / 2 - centerY * zoom,
-				zoom: {
-					value: zoom
-				}
-			}
-		});
-	}
+// Move all elements by the offset
+elements.forEach((el) => {
+if (el.type === 'line') {
+el.x += offsetX;
+el.y += offsetY;
+} else if (el.type === 'image' || el.type === 'rectangle' || el.type === 'ellipse') {
+el.x += offsetX;
+el.y += offsetY;
+}
+});
+}
 
-	function toggleFullscreen() {
-		if (!excalidrawAPI) return;
-		isFullscreen = !isFullscreen;
+return elements;
+}
 
-		if (isFullscreen) {
-			try {
-				tick().then(() => {
-					if (fullscreenExcalidrawAPI) {
-						const currentState = {
-							elements: excalidrawAPI.getSceneElements() || [],
-							appState: excalidrawAPI.getAppState() || {},
-							files: excalidrawAPI.getFiles() || {}
-						};
 
-						fullscreenExcalidrawAPI.updateScene(currentState);
-						setTimeout(() => zoomToIncludeAllElements(fullscreenExcalidrawAPI), 100);
-					}
-				});
-			} catch (error) {
-				console.error('Error initializing fullscreen mode:', error);
-				isFullscreen = false;
-			}
-		}
-	}
+onMount(async () => {
+if (!browser) return;
+if (hasInitialized) return;
 
-	async function createFullscreenComponent() {
-		try {
-			const React = await import('react');
-			const ReactDOM = await import('react-dom/client');
-			const { Excalidraw } = await import('@excalidraw/excalidraw');
+hasInitialized = true;
+try {
+// If there's no data or empty data, create from scratch; else fix and load existing data
+if (!data || (data.elements && data.elements.length === 0)) {
+initialSceneData = await createInitialImageElements(template);
+} else {
+const fixedElements = fixGuideRectanglePosition([...data.elements]);
+initialSceneData = {
+elements: fixedElements,
+appState: {
+viewBackgroundColor: '#ffffff',
+gridSize: 20,
+...(data.appState || {}),
+// Ensure we have a collaborators array
+collaborators: Array.isArray(data.appState?.collaborators)
+? data.appState.collaborators
+: []
+},
+files: data.files || {}
+};
+}
+ExcalidrawComponent = await createExcalidrawComponent({
+excalidrawAPI: (api) => {
+excalidrawAPI = api;
+if (!isFullscreen) {
+setTimeout(() => centerAndZoomToGuideRectangle(api), 100);
+}
+},
+initialData: initialSceneData,
+viewModeEnabled: readonly,
+onChange: handleChange,
+gridModeEnabled: false,
+theme: 'light',
+name: id,
+UIOptions: {
+canvasActions: { export: false, loadScene: false, saveAsImage: false, theme: false }
+}
+});
+await tick();
+} catch (error) {
+console.error('Error mounting Excalidraw:', error);
+}
+});
 
-			const excalidrawProps = {
-				onReady: (api) => {
-					fullscreenExcalidrawAPI = api;
-					if (initialSceneData) {
-						api.updateScene(initialSceneData);
-					}
-				},
-				initialData: initialSceneData,
-				viewModeEnabled: readonly,
-				onChange: handleChange,
-				gridModeEnabled: false,
-				theme: 'light',
-				name: `${id}-fullscreen`,
-				UIOptions: {
-					canvasActions: {
-						export: false,
-						loadScene: false,
-						saveAsImage: false,
-						theme: false
-					}
-				}
-			};
+// Add resize observer to handle container size changes
+onMount(() => {
+if (browser && excalidrawWrapper) {
+const resizeObserver = new ResizeObserver(() => {
+if (excalidrawAPI && !isFullscreen) {
+centerAndZoomToGuideRectangle(excalidrawAPI);
+}
+});
 
-			fullscreenExcalidrawComponent = {
-				render: (node) => {
-					const root = ReactDOM.createRoot(node);
-					root.render(
-						React.createElement(Excalidraw, { ...excalidrawProps, portalContainer: node })
-					);
-					return {
-						destroy: () => root.unmount()
-					};
-				}
-			};
-		} catch (error) {
-			console.error('Error creating fullscreen component:', error);
-			isFullscreen = false;
-		}
-	}
+resizeObserver.observe(excalidrawWrapper);
 
-	function handleSaveAndClose() {
-		if (!fullscreenExcalidrawAPI) return;
+return () => {
+resizeObserver.disconnect();
+};
+}
+});
 
-		try {
-			const elements = fullscreenExcalidrawAPI.getSceneElements();
-			const appState = fullscreenExcalidrawAPI.getAppState();
-			const files = fullscreenExcalidrawAPI.getFiles();
-
-			// Update initialData to match current state
-			initialSceneData = {
-				elements,
-				appState: { ...appState, viewBackgroundColor: appState.viewBackgroundColor },
-				files
-			};
-
-			isFullscreen = false;
-
-			tick().then(() => {
-				if (excalidrawAPI) {
-					// Update the preview with latest state
-					excalidrawAPI.updateScene(initialSceneData);
-					dispatch('save', initialSceneData);
-				}
-			});
-		} catch (error) {
-			console.error('Error in handleSaveAndClose:', error);
-			isFullscreen = false;
-		}
-	}
-
-	function handleCancel() {
-		isFullscreen = false;
-		// No need to restore state since we'll get fresh state next time
-	}
-
-	function handleChange(elements, appState, files) {
-		if (!readonly) {
-			const sceneData = {
-				elements,
-				appState: {
-					...appState,
-					collaborators: [] // Ensure collaborators exists
-				},
-				files
-			};
-			dispatch('save', sceneData);
-		}
-	}
-
-	function centerAndZoomToGuideRectangle(api) {
-		if (!api) return;
-
-		const elements = api.getSceneElements();
-		if (!elements.length) return;
-
-		// Find the guide rectangle
-		const guideRect = elements.find(
-			(el) => el.type === 'rectangle' && el.strokeColor === '#ff0000' && el.strokeStyle === 'dashed'
-		);
-
-		if (!guideRect) return;
-
-		// Calculate zoom level as before
-		const container = excalidrawWrapper?.querySelector('.excalidraw-container');
-		if (!container) return;
-
-		const containerWidth = container.offsetWidth;
-		const containerHeight = container.offsetHeight;
-
-		const zoomX = containerWidth / CANVAS_WIDTH;
-		const zoomY = containerHeight / CANVAS_HEIGHT;
-		const zoom = Math.min(zoomX, zoomY, 1);
-
-		// Set scroll position to align with guide rectangle
-		// Note: We use 0 for both X and Y to align with top-left
-		api.updateScene({
-			appState: {
-				...api.getAppState(),
-				scrollX: 0,
-				scrollY: 0,
-				zoom: {
-					value: zoom
-				}
-			}
-		});
-	}
-
-	function fixGuideRectanglePosition(elements) {
-		const guideRect = elements.find(
-			(el) => el.type === 'rectangle' && el.strokeColor === '#ff0000' && el.strokeStyle === 'dashed'
-		);
-
-		if (guideRect && (guideRect.x !== 0 || guideRect.y !== 0)) {
-			// Calculate the offset that needs to be applied to all elements
-			const offsetX = -guideRect.x;
-			const offsetY = -guideRect.y;
-
-			// Move all elements by the offset
-			elements.forEach((el) => {
-				if (el.type === 'line') {
-					el.x += offsetX;
-					el.y += offsetY;
-				} else if (el.type === 'image' || el.type === 'rectangle' || el.type === 'ellipse') {
-					el.x += offsetX;
-					el.y += offsetY;
-				}
-			});
-		}
-
-		return elements;
-	}
-
-	function handleImageElements(elements, files) {
-		elements.forEach((element) => {
-			if (element.type === 'image') {
-				const file = files[element.fileId];
-				if (file?.staticPath) {
-					element.staticImagePath = file.staticPath;
-				} else if (file?.dataURL) {
-					element.dataURL = file.dataURL;
-				} else {
-					console.warn('Image element missing both staticPath and dataURL:', {
-						elementId: element.fileId,
-						element: element
-					});
-				}
-			}
-		});
-		return elements;
-	}
-
-	onMount(async () => {
-		if (!browser) return;
-		if (hasInitialized) return;
-
-		hasInitialized = true;
-		try {
-			const React = await import('react');
-			const ReactDOM = await import('react-dom/client');
-			window.React = React.default;
-			const { Excalidraw } = await import('@excalidraw/excalidraw');
-
-			// If there's no data or empty data, create from scratch; else fix and load existing data
-			if (!data || (data.elements && data.elements.length === 0)) {
-				initialSceneData = await createInitialImageElements(template);
-			} else {
-				const fixedElements = fixGuideRectanglePosition([...data.elements]);
-				initialSceneData = {
-					elements: fixedElements,
-					appState: {
-						viewBackgroundColor: '#ffffff',
-						gridSize: 20,
-						collaborators: [],
-						...(data.appState || {}),
-						// Ensure we have a collaborators array
-						collaborators: Array.isArray(data.appState?.collaborators)
-							? data.appState.collaborators
-							: []
-					},
-					files: data.files || {}
-				};
-			}
-
-			// Use initialSceneData in both places:
-			const createExcalidrawProps = (isFullscreenVersion = false) => ({
-				excalidrawAPI: (api) => {
-					if (isFullscreenVersion) {
-						fullscreenExcalidrawAPI = api;
-					} else {
-						excalidrawAPI = api;
-						if (!isFullscreen) {
-							setTimeout(() => centerAndZoomToGuideRectangle(api), 100);
-						}
-					}
-				},
-				initialData: initialSceneData,
-				viewModeEnabled: readonly,
-				onChange: handleChange,
-				gridModeEnabled: false,
-				theme: 'light',
-				name: isFullscreenVersion ? `${id}-fullscreen` : id,
-				UIOptions: {
-					canvasActions: {
-						export: false,
-						loadScene: false,
-						saveAsImage: false,
-						theme: false
-					}
-				}
-			});
-
-			// Mount the normal Excalidraw component
-			ExcalidrawComponent = {
-				render: (node) => {
-					const root = ReactDOM.createRoot(node);
-					root.render(React.createElement(Excalidraw, createExcalidrawProps(false)));
-					return {
-						destroy: () => root.unmount()
-					};
-				}
-			};
-
-			// Mount the fullscreen Excalidraw component
-			fullscreenExcalidrawComponent = {
-				render: (node) => {
-					const root = ReactDOM.createRoot(node);
-					root.render(React.createElement(Excalidraw, createExcalidrawProps(true)));
-					return {
-						destroy: () => root.unmount()
-					};
-				}
-			};
-
-			await tick();
-		} catch (error) {
-			console.error('Error mounting Excalidraw:', error);
-		}
-	});
-
-	// Add resize observer to handle container size changes
-	onMount(() => {
-		if (browser && excalidrawWrapper) {
-			const resizeObserver = new ResizeObserver(() => {
-				if (excalidrawAPI && !isFullscreen) {
-					centerAndZoomToGuideRectangle(excalidrawAPI);
-				}
-			});
-
-			resizeObserver.observe(excalidrawWrapper);
-
-			return () => {
-				resizeObserver.disconnect();
-			};
-		}
-	});
-
-	export function saveDiagram() {
-		if (excalidrawAPI) {
-			const elements = excalidrawAPI.getSceneElements();
-			const appState = excalidrawAPI.getAppState();
-			const files = excalidrawAPI.getFiles();
-			const diagramData = { elements, appState, files };
-			dispatch('save', diagramData);
-			return diagramData;
-		}
-		return null;
-	}
+export function saveDiagram() {
+if (excalidrawAPI) {
+const elements = excalidrawAPI.getSceneElements();
+const appState = excalidrawAPI.getAppState();
+const files = excalidrawAPI.getFiles();
+const diagramData = { elements, appState, files };
+dispatch('save', diagramData);
+return diagramData;
+}
+return null;
+}
 </script>
 
 <div class="excalidraw-wrapper" bind:this={excalidrawWrapper}>
-	{#if browser && ExcalidrawComponent}
-		<div class="excalidraw-container" style="height: 600px;">
-			<div class="excalidraw-mount-point relative w-full h-full">
-				<button
-					type="button"
-					class="absolute top-2 right-2 z-10 px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md flex items-center gap-1"
-					on:click={() => {
-						toggleFullscreen();
-					}}
-					disabled={!excalidrawAPI}
-				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						class="h-5 w-5"
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
-					>
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-							d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"
-						/>
-					</svg>
-					<span class="text-sm">Fullscreen</span>
-				</button>
-				<div use:ExcalidrawComponent.render></div>
-			</div>
-		</div>
-	{/if}
-
-	<!-- Fullscreen Modal -->
-	{#if isFullscreen}
-		<div class="modal-overlay">
-			<div class="modal-content">
-				<div class="modal-header">
-					<h2 class="text-xl font-bold">Edit Diagram</h2>
-					<div class="flex gap-2">
-						<button
-							class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-							on:click={handleSaveAndClose}
-						>
-							Save & Close
-						</button>
-						<button
-							class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700"
-							on:click={handleCancel}
-						>
-							Cancel
-						</button>
-					</div>
-				</div>
-				<div class="editor-container" bind:this={fullscreenContainer}>
-					{#if fullscreenExcalidrawComponent}
-						<div
-							class="excalidraw-fullscreen-wrapper"
-							use:fullscreenExcalidrawComponent.render
-						></div>
-					{/if}
-				</div>
-			</div>
-		</div>
-	{/if}
+{#if browser && ExcalidrawComponent}
+<div class="excalidraw-container" style="height: 600px;">
+<div class="excalidraw-mount-point relative w-full h-full">
+<button
+type="button"
+class="absolute top-2 right-2 z-10 px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md flex items-center gap-1"
+on:click={() => {
+toggleFullscreen();
+}}
+disabled={!excalidrawAPI}
+>
+<svg
+xmlns="http://www.w3.org/2000/svg"
+class="h-5 w-5"
+fill="none"
+viewBox="0 0 24 24"
+stroke="currentColor"
+>
+<path
+stroke-linecap="round"
+stroke-linejoin="round"
+stroke-width="2"
+d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"
+/>
+</svg>
+<span class="text-sm">Fullscreen</span>
+</button>
+<div use:ExcalidrawComponent.render></div>
+</div>
+</div>
+{/if}
+{#if isFullscreen}
+<ExcalidrawModal
+{readonly}
+initialData={fullscreenData}
+on:save={handleModalSave}
+on:cancel={handleModalCancel}
+/>
+{/if}
 </div>
 
 <style>
-	/* Ensure Excalidraw fills the container */
-	:global(.excalidraw) {
-		width: 100% !important;
-		height: 100% !important;
-		min-height: 600px !important; /* Update from 500px to 600px */
-	}
+/* Ensure Excalidraw fills the container */
+:global(.excalidraw) {
+width: 100% !important;
+height: 100% !important;
+min-height: 600px !important; /* Update from 500px to 600px */
+}
 
-	:global(.excalidraw-wrapper) {
-		width: 100% !important;
-		height: 100% !important;
-		position: relative !important;
-	}
+:global(.excalidraw-wrapper) {
+width: 100% !important;
+height: 100% !important;
+position: relative !important;
+}
 
-	:global(.excalidraw .layer-ui__wrapper) {
-		position: absolute !important;
-	}
+:global(.excalidraw .layer-ui__wrapper) {
+position: absolute !important;
+}
 
-	/* Fix for fullscreen modal */
-	.modal-overlay {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background: rgba(0, 0, 0, 0.75);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		z-index: 9999;
-	}
-
-	.modal-content {
-		width: 95vw;
-		height: 95vh;
-		background: white;
-		display: flex;
-		flex-direction: column;
-		border-radius: 0.5rem;
-		overflow: hidden;
-	}
-
-	.modal-header {
-		padding: 1rem;
-		background-color: white;
-		border-bottom: 1px solid #e5e7eb;
-		z-index: 1;
-	}
-
-	.editor-container {
-		flex: 1;
-		position: relative;
-		overflow: hidden;
-	}
-
-	.excalidraw-fullscreen-wrapper {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		overflow: hidden;
-	}
-
-	/* Update Excalidraw specific styles */
-	:global(.excalidraw-fullscreen-wrapper .excalidraw) {
-		width: 100% !important;
-		height: 100% !important;
-	}
-
-	:global(.excalidraw-fullscreen-wrapper .excalidraw-container) {
-		width: 100% !important;
-		height: 100% !important;
-	}
-
-	/* Add specific mount point styling */
-	:global(.excalidraw-mount-point) {
-		position: absolute !important;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-	}
+:global(.excalidraw-mount-point) {
+position: absolute !important;
+top: 0;
+left: 0;
+right: 0;
+bottom: 0;
+}
 </style>

--- a/src/lib/utils/createExcalidrawComponent.js
+++ b/src/lib/utils/createExcalidrawComponent.js
@@ -1,0 +1,15 @@
+export async function createExcalidrawComponent(props) {
+const React = await import('react');
+const ReactDOM = await import('react-dom/client');
+const { Excalidraw } = await import('@excalidraw/excalidraw');
+
+return {
+render: (node) => {
+const root = ReactDOM.createRoot(node);
+root.render(React.createElement(Excalidraw, { ...props, portalContainer: node }));
+return {
+destroy: () => root.unmount()
+};
+}
+};
+}

--- a/src/routes/drills/DrillForm.svelte
+++ b/src/routes/drills/DrillForm.svelte
@@ -107,7 +107,11 @@
 		? allDrillNames.filter((d) => d.id !== drill?.id)
 		: [];
 
-	let diagramRefs = [];
+       let diagramRefs = [];
+       // Ensure refs array matches diagrams length
+       $: if ($diagrams) {
+               diagramRefs = new Array($diagrams.length);
+       }
 
 	const drillTypeOptions = [
 		'Competitive',
@@ -161,24 +165,27 @@
 		diagramKey++;
 	}
 
-	function handleDiagramSave(event, index) {
-		const diagramData = event.detail;
-		const processedData = {
-			elements: diagramData.elements || [],
-			appState: {
-				...(diagramData.appState || {}),
-				collaborators: Array.isArray(diagramData.appState?.collaborators)
-					? diagramData.appState.collaborators
-					: []
-			},
-			files: diagramData.files || {}
-		};
-		diagrams.update((d) => {
-			const newDiagrams = [...d];
-			newDiagrams[index] = processedData;
-			return newDiagrams;
-		});
-	}
+       function handleDiagramSave(event, index) {
+               const diagramData = event.detail;
+               const processedData = {
+                       elements: diagramData.elements || [],
+                       appState: {
+                               viewBackgroundColor: '#ffffff',
+                               gridSize: 20,
+                               ...(diagramData.appState || {}),
+                               collaborators: Array.isArray(diagramData.appState?.collaborators)
+                                       ? diagramData.appState.collaborators
+                                       : []
+                       },
+                       files: diagramData.files || {},
+                       template: $diagrams[index]?.template || 'blank'
+               };
+               diagrams.update((d) => {
+                       const newDiagrams = [...d];
+                       newDiagrams[index] = processedData;
+                       return newDiagrams;
+               });
+       }
 
 	function handleMoveUp(index) {
 		moveDiagram(index, -1);
@@ -939,16 +946,116 @@
 							<p class="text-red-500 text-sm mt-1">{$errors.positions_focused_on}</p>
 						{/if}
 
-						<div class="flex flex-col">
-							<label for="video_link" class="mb-1 text-sm font-medium text-gray-700"
-								>Video Link:</label
-							>
-							<input
-								id="video_link"
-								bind:value={$video_link}
-								class="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-							/>
-						</div>
+<div class="flex flex-col">
+<label for="video_link" class="mb-1 text-sm font-medium text-gray-700"
+>Video Link:</label
+>
+<input
+id="video_link"
+bind:value={$video_link}
+class="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+/>
+</div>
+
+<!-- Diagrams Section -->
+<div class="mb-6">
+<label class="block text-gray-700 font-medium mb-2" for="diagrams">
+Diagrams
+<span class="text-sm text-gray-500 font-normal"
+>(Optional - Add visual diagrams to illustrate your drill)</span
+>
+</label>
+
+{#if $diagrams && $diagrams.length > 0}
+<div class="space-y-4 mb-4">
+{#each $diagrams as diagram, diagramIndex (diagramIndex)}
+<div class="border border-gray-300 rounded-lg bg-white shadow-sm overflow-hidden">
+<div class="bg-gray-50 px-4 py-3 border-b border-gray-200">
+<div class="flex justify-between items-center">
+<h4 class="text-lg font-medium text-gray-700">
+Diagram {diagramIndex + 1}
+{#if diagram.template && diagram.template !== 'blank'}
+<span class="text-sm text-gray-500 ml-2">
+({diagram.template.replace(/([A-Z])/g, ' $1').trim()})
+</span>
+{/if}
+</h4>
+<div class="flex items-center gap-2">
+<div class="flex gap-1 mr-2">
+<button
+type="button"
+on:click={() => handleMoveUp(diagramIndex)}
+disabled={diagramIndex === 0}
+class="p-1 text-gray-600 hover:text-gray-800 disabled:text-gray-400 disabled:cursor-not-allowed"
+title="Move up"
+>
+<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+</svg>
+</button>
+<button
+type="button"
+on:click={() => handleMoveDown(diagramIndex)}
+disabled={diagramIndex === $diagrams.length - 1}
+class="p-1 text-gray-600 hover:text-gray-800 disabled:text-gray-400 disabled:cursor-not-allowed"
+title="Move down"
+>
+<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+</svg>
+</button>
+</div>
+<button
+type="button"
+on:click={() => duplicateDiagram(diagramIndex)}
+class="px-3 py-1 text-sm bg-blue-100 text-blue-700 hover:bg-blue-200 rounded-md transition-colors"
+>
+Duplicate
+</button>
+<button
+type="button"
+on:click={() => deleteDiagram(diagramIndex)}
+class="px-3 py-1 text-sm bg-red-100 text-red-700 hover:bg-red-200 rounded-md transition-colors"
+>
+Delete
+</button>
+</div>
+</div>
+</div>
+
+<div class="p-4">
+<div class="excalidraw-form-container" style="height: 500px;">
+<ExcalidrawWrapper
+data={diagram}
+id={`drill-${drill.id || 'new'}-diagram-${diagramIndex}`}
+readonly={false}
+template={diagram.template || 'blank'}
+startFullscreen={false}
+on:save={(event) => handleDiagramSave(event, diagramIndex)}
+bind:this={diagramRefs[diagramIndex]}
+/>
+</div>
+</div>
+</div>
+{/each}
+</div>
+{/if}
+
+<button
+type="button"
+on:click={() => (showAddDiagramModal = true)}
+class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+>
+<svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+</svg>
+Add Diagram
+</button>
+
+<p class="mt-2 text-sm text-gray-500">
+Use diagrams to show field setup, player positions, movement patterns, or drill progressions.
+</p>
+</div>
 
 						<div class="flex flex-col">
 							<label for="visibility-select" class="mb-1 text-sm font-medium text-gray-700"
@@ -1140,9 +1247,20 @@
 		color: white;
 	}
 
-	:global(.dndzone.dropzone) {
-		background-color: rgba(59, 130, 246, 0.1);
-	}
+        :global(.dndzone.dropzone) {
+                background-color: rgba(59, 130, 246, 0.1);
+        }
+
+        .excalidraw-form-container {
+                border: 1px solid #e5e7eb;
+                border-radius: 0.375rem;
+                overflow: hidden;
+                position: relative;
+        }
+
+        .excalidraw-form-container :global(.excalidraw) {
+                background: #ffffff;
+        }
 
 	textarea {
 		min-height: 60px;

--- a/src/routes/drills/[id]/+page.svelte
+++ b/src/routes/drills/[id]/+page.svelte
@@ -492,12 +492,11 @@
 								<!-- Removed unused 'key' directive -->
 								<div class="border rounded-lg p-2">
 									<h3 class="text-center font-medium mb-2">Diagram {index + 1}</h3>
-									<ExcalidrawWrapper
-										data={diagramData}
-										id={`diagram-${$drill.id}-${index}`}
-										{index}
-										viewOnly={true}
-									/>
+                                                                       <ExcalidrawWrapper
+                                                                               data={diagramData}
+                                                                               id={`diagram-${$drill.id}-${index}`}
+                                                                               readonly={true}
+                                                                        />
 								</div>
 							{/each}
 						{/if}

--- a/src/routes/drills/bulk-upload/+page.svelte
+++ b/src/routes/drills/bulk-upload/+page.svelte
@@ -670,13 +670,12 @@ Example Drill,A brief description,A more detailed description,"Competitive,Skill
 							<div class="mb-4">
 								<h4 class="text-lg font-semibold mb-2">Diagrams:</h4>
 								{#each drill.diagrams as diagram, diagIndex (diagIndex)}
-									<ExcalidrawWrapper
-										data={diagram}
-										{index}
-										{diagIndex}
-										showSaveButton={drill.editableDiagramIndex === diagIndex}
-										on:save={(event) => saveDiagram(index, diagIndex, event)}
-									/>
+                                                                        <ExcalidrawWrapper
+                                                                               data={diagram}
+                                                                               id={`bulk-drill-${index}-diagram-${diagIndex}`}
+                                                                               readonly={drill.editableDiagramIndex !== diagIndex}
+                                                                               on:save={(event) => saveDiagram(index, diagIndex, event)}
+                                                                        />
 									{#if drill.editableDiagramIndex === diagIndex}
 										<button on:click={() => cancelEditDiagram(index)} class="text-gray-500 mt-2"
 											>Cancel</button
@@ -775,13 +774,12 @@ Example Drill,A brief description,A more detailed description,"Competitive,Skill
 							<div class="mb-4">
 								<h4 class="text-lg font-semibold mb-2">Diagrams:</h4>
 								{#each drill.diagrams as diagram, diagIndex (diagIndex)}
-									<ExcalidrawWrapper
-										data={diagram}
-										{index}
-										{diagIndex}
-										showSaveButton={drill.editableDiagramIndex === diagIndex}
-										on:save={(event) => saveDiagram(index, diagIndex, event)}
-									/>
+                                                                        <ExcalidrawWrapper
+                                                                               data={diagram}
+                                                                               id={`bulk-drill-${index}-diagram-${diagIndex}`}
+                                                                               readonly={drill.editableDiagramIndex !== diagIndex}
+                                                                               on:save={(event) => saveDiagram(index, diagIndex, event)}
+                                                                        />
 									{#if drill.editableDiagramIndex === diagIndex}
 										<button on:click={() => cancelEditDiagram(index)} class="text-gray-500 mt-2"
 											>Cancel</button

--- a/src/routes/formations/FormationForm.svelte
+++ b/src/routes/formations/FormationForm.svelte
@@ -63,7 +63,10 @@
 	let errors = writable({});
 	let mounted = false;
 	let diagramKey = 0;
-	let diagramRefs = [];
+let diagramRefs = [];
+$: if ($diagrams) {
+       diagramRefs = new Array($diagrams.length);
+}
 
 	let showAddDiagramModal = false;
 	let selectedTemplate = 'blank';
@@ -121,16 +124,19 @@
 		const diagramData = event.detail;
 
 		// Ensure proper structure when saving
-		const processedData = {
-			elements: diagramData.elements || [],
-			appState: {
-				...(diagramData.appState || {}),
-				collaborators: Array.isArray(diagramData.appState?.collaborators)
-					? diagramData.appState.collaborators
-					: []
-			},
-			files: diagramData.files || {}
-		};
+       const processedData = {
+               elements: diagramData.elements || [],
+               appState: {
+                       viewBackgroundColor: '#ffffff',
+                       gridSize: 20,
+                       ...(diagramData.appState || {}),
+                       collaborators: Array.isArray(diagramData.appState?.collaborators)
+                               ? diagramData.appState.collaborators
+                               : []
+               },
+               files: diagramData.files || {},
+               template: $diagrams[index]?.template || 'blank'
+       };
 
 		diagrams.update((d) => {
 			const newDiagrams = [...d];
@@ -738,13 +744,14 @@
 											</button>
 										</div>
 									</div>
-									<ExcalidrawWrapper
-										data={diagram}
-										id={`diagram-${i}`}
-										index={i}
-										bind:this={diagramRefs[i]}
-										on:save={(event) => handleDiagramSave(event, i)}
-									/>
+                                                                        <ExcalidrawWrapper
+                                                                               data={diagram}
+                                                                               id={`diagram-${i}`}
+                                                                               readonly={false}
+                                                                               template={diagram.template || 'blank'}
+                                                                               bind:this={diagramRefs[i]}
+                                                                               on:save={(event) => handleDiagramSave(event, i)}
+                                                                        />
 								</div>
 							{/each}
 

--- a/src/routes/formations/[id]/+page.svelte
+++ b/src/routes/formations/[id]/+page.svelte
@@ -185,13 +185,11 @@
 										<h3 class="font-medium text-gray-700">Diagram {diagram.name || i + 1}</h3>
 									</div>
 									<div class="p-4 bg-gray-100">
-										<ExcalidrawWrapper
-											data={diagram}
-											id={`view-diagram-${formation.id}-${i}`}
-											readonly={true}
-											viewModeEnabled={true}
-											zenModeEnabled={false}
-										/>
+                                                                       <ExcalidrawWrapper
+                                                                               data={diagram}
+                                                                               id={`view-diagram-${formation.id}-${i}`}
+                                                                               readonly={true}
+                                                                               />
 									</div>
 								</div>
 							{/if}

--- a/src/routes/practice-plans/viewer/DrillCard.svelte
+++ b/src/routes/practice-plans/viewer/DrillCard.svelte
@@ -265,17 +265,17 @@
 				{#if normalizedItem.hasDiagrams}
 					<div class="diagrams-preview">
 						{#if normalizedItem.drill?.diagrams?.[0]}
-							<ExcalidrawWrapper
-								data={normalizedItem.drill.diagrams[0]}
-								readonly={true}
-								showSaveButton={false}
-							/>
+                                                        <ExcalidrawWrapper
+                                                                data={normalizedItem.drill.diagrams[0]}
+                                                                id={`plan-diagram-${item.drill_id}-0`}
+                                                                readonly={true}
+                                                        />
 						{:else if normalizedItem.diagrams?.[0]}
-							<ExcalidrawWrapper
-								data={normalizedItem.diagrams[0]}
-								readonly={true}
-								showSaveButton={false}
-							/>
+                                                        <ExcalidrawWrapper
+                                                                data={normalizedItem.diagrams[0]}
+                                                                id={`plan-diagram-${index}-0`}
+                                                                readonly={true}
+                                                        />
 						{/if}
 					</div>
 				{/if}


### PR DESCRIPTION
## Summary
- add new ExcalidrawModal component and util for creating components
- refactor ExcalidrawWrapper to use fullscreen modal API
- render diagrams in DrillForm with controls
- update bulk upload and formation pages for new wrapper props
- update practice plan drill card and renderer

## Testing
- `pnpm run lint` *(fails: code style issues)*
- `pnpm test` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687c02e3c5748325a2311b0624b856fc